### PR TITLE
save report space by printing integer percentages for noise tolerances

### DIFF
--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -459,9 +459,11 @@ end
 
 idrepr(id) = (str = repr(id); str[searchindex(str, '['):end])
 
+intpercent(p) = string(ceil(Int, p * 100), "%")
+
 function resultrow(ids, t::BenchmarkTools.TrialEstimate)
-    t_tol = BenchmarkTools.prettypercent(BenchmarkTools.params(t).time_tolerance)
-    m_tol = BenchmarkTools.prettypercent(BenchmarkTools.params(t).memory_tolerance)
+    t_tol = intpercent(BenchmarkTools.params(t).time_tolerance)
+    m_tol = intpercent(BenchmarkTools.params(t).memory_tolerance)
     timestr = string(BenchmarkTools.prettytime(BenchmarkTools.time(t)), " (", t_tol, ")")
     memstr = string(BenchmarkTools.prettymemory(BenchmarkTools.memory(t)), " (", m_tol, ")")
     gcstr = BenchmarkTools.prettytime(BenchmarkTools.gctime(t))
@@ -470,8 +472,8 @@ function resultrow(ids, t::BenchmarkTools.TrialEstimate)
 end
 
 function resultrow(ids, t::BenchmarkTools.TrialJudgement)
-    t_tol = BenchmarkTools.prettypercent(BenchmarkTools.params(t).time_tolerance)
-    m_tol = BenchmarkTools.prettypercent(BenchmarkTools.params(t).memory_tolerance)
+    t_tol = intpercent(BenchmarkTools.params(t).time_tolerance)
+    m_tol = intpercent(BenchmarkTools.params(t).memory_tolerance)
     t_ratio = @sprintf("%.2f", BenchmarkTools.time(BenchmarkTools.ratio(t)))
     m_ratio =  @sprintf("%.2f", BenchmarkTools.memory(BenchmarkTools.ratio(t)))
     t_mark = resultmark(BenchmarkTools.time(t))

--- a/test/report.md
+++ b/test/report.md
@@ -29,9 +29,9 @@ benchmark results remained invariant between builds).
 
 | ID | time ratio | memory ratio |
 |----|------------|--------------|
-| `["g","h","z"]` | 1.00 (60.00%)  | 5.00 (27.00%) :x: |
-| `["g","h",("y",1)]` | 2.00 (5.00%) :x: | 0.00 (3.00%) :white_check_mark: |
-| `["g","h",("y",2)]` | 0.50 (5.00%) :white_check_mark: | 1.00 (1.00%)  |
+| `["g","h","z"]` | 1.00 (60%)  | 5.00 (27%) :x: |
+| `["g","h",("y",1)]` | 2.00 (5%) :x: | 0.00 (3%) :white_check_mark: |
+| `["g","h",("y",2)]` | 0.50 (5%) :white_check_mark: | 1.00 (1%)  |
 
 ## Benchmark Group List
 


### PR DESCRIPTION
@tkelman [You make a good point](https://github.com/JuliaCI/BenchmarkTools.jl/pull/3#issuecomment-218934417).