### PR TITLE
add support for daily benchmark jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ The `vs` keyword argument takes a reference string which can points to a Julia c
 - `"owner/repo:branch"`: the head commit of the branch named `branch` in the repository `owner/repo`
 - `"owner/repo@sha"`: the commit specified by `sha` in the repository `owner/repo`
 
+##### Benchmark Results
+
+Once a `BenchmarjJob` is complete, the results are uploaded to the
+[BaseBenchmarkReports](https://github.com/JuliaCI/BaseBenchmarkReports) repository. Each job
+has its own directory for results. This directory contains the following items:
+
+- `report.md` is a markdown report that summarizes the job results
+- `data.tar.gz` contains raw timing data in JLD format. To untar this file, run
+`tar -xzvf data.tar.gz`. You can analyze this data using the
+[BenchmarkTools](https://github.com/JuliaCI/BaseBenchmarkReports) package.
+- `logs` is a directory containing the build logs and benchmark execution logs for the job.
+
 ##### Comment Examples
 
 Here are some examples of comments that trigger a `BenchmarkJob` in various contexts:

--- a/bin/submit_daily_job.jl
+++ b/bin/submit_daily_job.jl
@@ -1,0 +1,12 @@
+import GitHub
+
+auth = GitHub.authenticate(ENV["GITHUB_AUTH"])
+repo = "JuliaLang/julia"
+sha = get(get(GitHub.branch(repo, "master").commit).sha)
+message = """
+          Executing the daily benchmark build, I will reply here when finished:
+
+          @nanosoldier `runbenchmarks(ALL, isdaily = true)`
+          """
+
+GitHub.create_comment(repo, sha, :commit, auth = auth, params = Dict("body" => message))

--- a/src/Nanosoldier.jl
+++ b/src/Nanosoldier.jl
@@ -13,7 +13,7 @@ snipsha(sha) = snip(sha, 7)
 
 gitclone!(repo, path) = run(`git clone git@github.com:$(repo).git $(path)`)
 
-gitreset!() = run(`git fetch --all && git reset --hard origin/master`)
+gitreset!() = (run(`git fetch --all`); run(`git reset --hard origin/master`))
 gitreset!(path) = cd(gitreset!, path)
 
 include("config.jl")

--- a/src/Nanosoldier.jl
+++ b/src/Nanosoldier.jl
@@ -11,7 +11,7 @@ const BRANCH_SEPARATOR = ':'
 snip(str, len) = length(str) > len ? str[1:len] : str
 snipsha(sha) = snip(sha, 7)
 
-gitclone!(repo, path) = run(`git clone https://github.com/$(repo) $(path)`)
+gitclone!(repo, path) = run(`git clone git@github.com:$(repo).git $(path)`)
 
 gitreset!() = run(`git fetch --all && git reset --hard origin/master`)
 gitreset!(path) = cd(gitreset!, path)

--- a/src/Nanosoldier.jl
+++ b/src/Nanosoldier.jl
@@ -11,6 +11,11 @@ const BRANCH_SEPARATOR = ':'
 snip(str, len) = length(str) > len ? str[1:len] : str
 snipsha(sha) = snip(sha, 7)
 
+gitclone!(repo, path) = run(`git clone https://github.com/$(repo) $(path)`)
+
+gitreset!() = run(`git fetch --all && git reset --hard origin/master`)
+gitreset!(path) = cd(gitreset!, path)
+
 include("config.jl")
 include("build.jl")
 include("submission.jl")

--- a/src/build.jl
+++ b/src/build.jl
@@ -28,7 +28,7 @@ function build_julia!(config::Config, build::BuildRef, prnumber::Nullable{Int} =
     if !(isnull(prnumber))
         pr = get(prnumber)
         # clone from `trackrepo`, not `build.repo`, since that's where the merge commit is
-        run(`git clone --quiet https://github.com/$(config.trackrepo) $(builddir)`)
+        gitclone!(config.trackrepo, builddir)
         cd(builddir)
         try
             run(`git fetch --quiet origin +refs/pull/$(pr)/merge:`)
@@ -40,7 +40,7 @@ function build_julia!(config::Config, build::BuildRef, prnumber::Nullable{Int} =
         run(`git checkout --quiet --force FETCH_HEAD`)
         build.sha = readchomp(`git rev-parse HEAD`)
     else
-        run(`git clone --quiet https://github.com/$(build.repo) $(builddir)`)
+        gitclone!(build.repo, builddir)
         cd(builddir)
         run(`git checkout --quiet $(build.sha)`)
     end

--- a/src/build.jl
+++ b/src/build.jl
@@ -19,7 +19,7 @@ end
 Base.summary(build::BuildRef) = string(build.repo, SHA_SEPARATOR, snipsha(build.sha))
 
 # if a PR number is included, attempt to build from the PR's merge commit
-function build_julia!(config::Config, build::BuildRef, prnumber::Nullable{Int} = Nullable{Int}())
+function build_julia!(config::Config, build::BuildRef, logpath, prnumber::Nullable{Int} = Nullable{Int}())
     # make a temporary workdir for our build
     builddir = mktempdir(workdir(config))
     cd(workdir(config))
@@ -47,8 +47,8 @@ function build_julia!(config::Config, build::BuildRef, prnumber::Nullable{Int} =
 
     # set up logs for STDOUT and STDERR
     logname = string(build.sha, "_build")
-    outfile = joinpath(logdir(config), string(logname, ".out"))
-    errfile = joinpath(logdir(config), string(logname, ".err"))
+    outfile = joinpath(logpath, string(logname, ".out"))
+    errfile = joinpath(logpath, string(logname, ".err"))
 
     # run the build
     run(pipeline(`make`, stdout = outfile, stderr = errfile))

--- a/src/config.jl
+++ b/src/config.jl
@@ -24,19 +24,25 @@ end
 # the shared space in which child nodes can work
 workdir(config::Config) = config.workdir
 
-# the directory where results are stored
-resultdir(config::Config) = joinpath(workdir(config), "results")
+# the report repository
+reportrepo(config::Config) = config.reportrepo
+
+# the local directory of the report repository
+reportdir(config::Config) = joinpath(workdir(config), split(reportrepo(config), "/")[2])
 
 # the directory where build logs are stored
 logdir(config::Config) = joinpath(workdir(config), "logs")
 
-# ensure directories exists
 persistdir!(path) = (!(isdir(path)) && mkdir(path); return path)
 
 function persistdir!(config::Config)
     persistdir!(workdir(config))
-    persistdir!(resultdir(config))
     persistdir!(logdir(config))
+    if isdir(reportdir(config))
+        gitreset!(reportdir(config))
+    else
+        gitclone!(reportrepo(config), reportdir(config))
+    end
 end
 
 function nodelog(config::Config, node, message)

--- a/src/config.jl
+++ b/src/config.jl
@@ -30,14 +30,10 @@ reportrepo(config::Config) = config.reportrepo
 # the local directory of the report repository
 reportdir(config::Config) = joinpath(workdir(config), split(reportrepo(config), "/")[2])
 
-# the directory where build logs are stored
-logdir(config::Config) = joinpath(workdir(config), "logs")
-
 persistdir!(path) = (!(isdir(path)) && mkdir(path); return path)
 
 function persistdir!(config::Config)
     persistdir!(workdir(config))
-    persistdir!(logdir(config))
     if isdir(reportdir(config))
         gitreset!(reportdir(config))
     else
@@ -46,8 +42,8 @@ function persistdir!(config::Config)
 end
 
 function nodelog(config::Config, node, message)
-    persistdir!(logdir(config))
-    open(joinpath(logdir(config), "node$(node).log"), "a") do file
+    persistdir!(workdir(config))
+    open(joinpath(workdir(config), "node$(node).log"), "a") do file
         println(file, now(), " | ", node, " | ", message)
     end
 end

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -173,7 +173,7 @@ function Base.run(job::BenchmarkJob)
     nodelog(cfg, node, "running primary build for $(summary(job))")
     primary_results = execute_benchmarks!(job, :primary)
     nodelog(cfg, node, "finished primary build for $(summary(job))")
-    results = Dict("primary" => primary_results)
+    results = Dict{Any,Any}("primary" => primary_results)
 
     # gather results to compare against
     if job.isdaily # get results from previous day (if it exists, check the past 30 days)
@@ -210,13 +210,12 @@ function Base.run(job::BenchmarkJob)
         end
     elseif !(isnull(job.against)) # run comparison build
         nodelog(cfg, node, "running comparison build for $(summary(job))")
-        against_results = execute_benchmarks!(job, :against)
+        results["against"] = execute_benchmarks!(job, :against)
         nodelog(cfg, node, "finished comparison build for $(summary(job))")
-        results["against"] = against_results
     end
 
     if haskey(results, "against")
-        results["judged"] = BenchmarkTools.judge(minimum(primary_results), minimum(against_results))
+        results["judged"] = BenchmarkTools.judge(minimum(primary_results), minimum(results["against"]))
     end
 
     # report results

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -151,6 +151,10 @@ function Base.run(job::BenchmarkJob)
     cd(oldpwd)
 
     # make data directory for job
+    if isdir(reportdir(job))
+        nodelog(cfg, node, "removing old job directory from report repository")
+        rm(reportdir(job), recursive = true)
+    end
     nodelog(cfg, node, "creating job directories in report repository")
     nodelog(cfg, node, "...creating $(reportdir(job))...")
     mkdir(reportdir(job))

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -543,6 +543,8 @@ idrepr(id) = (str = repr(id); str[searchindex(str, '['):end])
 
 intpercent(p) = string(ceil(Int, p * 100), "%")
 
+resultrow(ids, t::BenchmarkTools.Trial) = resultrow(ids, minimum(t))
+
 function resultrow(ids, t::BenchmarkTools.TrialEstimate)
     t_tol = intpercent(BenchmarkTools.params(t).time_tolerance)
     m_tol = intpercent(BenchmarkTools.params(t).memory_tolerance)

--- a/src/jobs/jobs.jl
+++ b/src/jobs/jobs.jl
@@ -10,7 +10,7 @@ abstract AbstractJob
 
 reply_status(job::AbstractJob, args...; kwargs...) = reply_status(submission(job), args...; kwargs...)
 reply_comment(job::AbstractJob, args...; kwargs...) = reply_comment(submission(job), args...; kwargs...)
-upload_report_file(job::AbstractJob, args...; kwargs...) = upload_report_file(submission(job), args...; kwargs...)
+upload_report_repo!(job::AbstractJob, args...; kwargs...) = upload_report_repo!(submission(job), args...; kwargs...)
 
 include("BenchmarkJob.jl")
 include("PkgEvalJob.jl")

--- a/src/server.jl
+++ b/src/server.jl
@@ -45,7 +45,7 @@ end
 
 function Base.run(server::Server, args...; kwargs...)
     @assert myid() == 1 "Nanosoldier server must be run from the master node"
-    persistdir!(server.config)
+    persistdir!(workdir(server.config))
     # Schedule a task for each node that feeds the node a job from the
     # queque once the node has completed its primary job. If the queue is
     # empty, then the task will call `yield` in order to avoid a deadlock.

--- a/src/submission.jl
+++ b/src/submission.jl
@@ -97,6 +97,7 @@ function parse_phrase_match(phrase_match::AbstractString)
         started_kwargs = false
         for x in parsed_args.args
             if isa(x, Expr) && (x.head == :kw || x.head == :(=)) && isa(x.args[1], Symbol)
+                @assert !(haskey(kwargs, x.args[1])) "kwargs must all be unique"
                 kwargs[x.args[1]] = phrase_argument(x.args[2])
                 started_kwargs = true
             else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,13 +55,13 @@ build_test_submission("@nanosoldier `runbenchmarks(ALL, vs = \"JuliaLang/julia:m
 build_test_submission("@nanosoldier `runbenchmarks(\"tag\", vs = \"JuliaLang/julia:master\")`")
 build_test_submission("@nanosoldier `runbenchmarks($tagpred, vs = \"JuliaLang/julia:master\")`")
 
-build_test_submission("@nanosoldier `runbenchmarks(ALL, daily = true, vs = \"JuliaLang/julia:master\")`")
-build_test_submission("@nanosoldier `runbenchmarks(\"tag\", daily = true, vs = \"JuliaLang/julia:master\")`")
-build_test_submission("@nanosoldier `runbenchmarks($tagpred, daily = true, vs = \"JuliaLang/julia:master\")`")
+build_test_submission("@nanosoldier `runbenchmarks(ALL, isdaily = true, vs = \"JuliaLang/julia:master\")`")
+build_test_submission("@nanosoldier `runbenchmarks(\"tag\", isdaily = true, vs = \"JuliaLang/julia:master\")`")
+build_test_submission("@nanosoldier `runbenchmarks($tagpred, isdaily = true, vs = \"JuliaLang/julia:master\")`")
 
-build_test_submission("@nanosoldier `runbenchmarks(ALL; daily = true, vs = \"JuliaLang/julia:master\")`")
-build_test_submission("@nanosoldier `runbenchmarks(\"tag\"; daily = true, vs = \"JuliaLang/julia:master\")`")
-build_test_submission("@nanosoldier `runbenchmarks($tagpred; daily = true, vs = \"JuliaLang/julia:master\")`")
+build_test_submission("@nanosoldier `runbenchmarks(ALL; isdaily = true, vs = \"JuliaLang/julia:master\")`")
+build_test_submission("@nanosoldier `runbenchmarks(\"tag\"; isdaily = true, vs = \"JuliaLang/julia:master\")`")
+build_test_submission("@nanosoldier `runbenchmarks($tagpred; isdaily = true, vs = \"JuliaLang/julia:master\")`")
 
 #########################
 # job report generation #


### PR DESCRIPTION
This PR contains what I worked on this weekend to prepare @nanosoldier to run daily benchmark jobs (see JuliaLang/julia#13893).

Changes:
- slightly improved job submission phrase validation/tests
- raw benchmark data + logs are now uploaded as tarred JLD + text files 
- add `isdaily` keyword argument to submission phrase that modifies the job to...
    - format the report folder name as `daily_YYYY_MM_DD`, using the current day's date
    - compare the current day's results to the previous day's results (if the previous day's results exist; it'll look back up to 30 days). 

TODO:
- [x] do a test deployment with these changes
- [x] set up a cron job that causes @nanosoldier to regularly submit CI jobs to itself using the `isdaily` keyword argument

cc @tkelman 