### PR TITLE
Construct report permalink manually instead of from requested file info

### DIFF
--- a/src/submission.jl
+++ b/src/submission.jl
@@ -137,6 +137,5 @@ function upload_report_repo!(sub::JobSubmission, markdownpath, message)
         run(`git push`)
         return headsha
     end
-    reportfile = GitHub.file(reportrepo(cfg), markdownpath; auth = cfg.auth)
-    return string(GitHub.permalink(reportfile, sha))
+    return "https://github.com/$(reportrepo(cfg))/blob/$(sha)/$(markdownpath)"
 end


### PR DESCRIPTION
Should fix the bug seen [here](https://github.com/JuliaLang/julia/pull/16260#issuecomment-225463265).