### PR TITLE
better default for versioninfo failure message

### DIFF
--- a/src/Nanosoldier.jl
+++ b/src/Nanosoldier.jl
@@ -34,7 +34,10 @@ end
 
 NanosoldierError{E<:Exception}(msg, err::E) = NanosoldierError{E}("", msg, err)
 
-Base.show(io::IO, err::NanosoldierError) = print(io, "NanosoldierError: ", err.msg, ": ", err.err)
+function Base.show(io::IO, err::NanosoldierError)
+    print(io, "NanosoldierError: ", err.msg, ": ")
+    showerror(io, err.err)
+end
 
 ############
 # includes #

--- a/src/build.jl
+++ b/src/build.jl
@@ -8,7 +8,7 @@ type BuildRef
     vinfo::UTF8String # versioninfo() taken during the build
 end
 
-BuildRef(repo, sha) = BuildRef(repo, sha, "?")
+BuildRef(repo, sha) = BuildRef(repo, sha, "retrieving versioninfo() failed")
 
 function @compat(Base.:(==))(a::BuildRef, b::BuildRef)
     return (a.repo == b.repo &&

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -370,6 +370,8 @@ function execute_benchmarks!(job::BenchmarkJob, whichbuild::Symbol)
     # environment information that is useless/potentially risky to expose.
     try
         build.vinfo = first(split(readstring(`$(juliapath) -e 'versioninfo(true)'`), "Environment"))
+    catch err
+        build.vinfo = "retrieving versioninfo() failed: $err"
     end
 
     cd(workdir(cfg))

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -151,7 +151,7 @@ function retrieve_daily_data!(results, key, cfg, date)
                     found_previous_date = true
                 end
             catch err
-                nodelog(cfg, myid(), "encountered error when retrieving daily data: $err")
+                nodelog(cfg, myid(), string("encountered error when retrieving daily data: ", sprint(showerror, err)))
             finally
                 isdir(datapath) && rm(datapath, recursive = true)
             end
@@ -371,7 +371,7 @@ function execute_benchmarks!(job::BenchmarkJob, whichbuild::Symbol)
     try
         build.vinfo = first(split(readstring(`$(juliapath) -e 'versioninfo(true)'`), "Environment"))
     catch err
-        build.vinfo = "retrieving versioninfo() failed: $err"
+        build.vinfo = string("retrieving versioninfo() failed: ", sprint(showerror, err))
     end
 
     cd(workdir(cfg))

--- a/src/submission.jl
+++ b/src/submission.jl
@@ -17,7 +17,7 @@ function JobSubmission(config::Config, event::GitHub.WebhookEvent, submission_st
         func, args, kwargs = parse_submission_string(submission_string)
         return JobSubmission(config, build, statussha, url, fromkind, prnumber, func, args, kwargs)
     catch err
-        error("could not parse comment into job submission: $err")
+        error(string("could not parse comment into job submission: ", sprint(showerror, err)))
     end
 end
 


### PR DESCRIPTION
I meant to change this default a long time ago, but it got overlooked. [One of Nanosoldier's jobs just reminded me, however](https://github.com/JuliaCI/BaseBenchmarkReports/blob/0d39a0ae9ef33c9e7faa320a84f8ae391d852a78/9f80457_vs_fab13f2/report.md#version-info) (thanks for pointing this out, @yuyichao). 