### PR TITLE
automatically run Pkg.update() before executing benchmarks

### DIFF
--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -272,6 +272,9 @@ function execute_benchmarks!(job::BenchmarkJob, whichbuild::Symbol)
 
     cd(builddir)
 
+    # update local Julia packages for the relevant Julia version
+    run(`$juliapath -e 'Pkg.update()'`)
+
     # The following code sets up a CPU shield, then spins up a new julia process on the
     # shielded CPU that runs the benchmarks. The results from this new process are
     # then serialized to a JLD file so that we can retrieve them.


### PR DESCRIPTION
Note that package updates still won't be reflected in running Nanosoldier processes until the server undergoes a restart, but benchmark processes (which are spawned afresh for every new build) may benefit from this.