### PR TITLE
Update Nanosoldier to Julia 0.6 and JSON benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: julia
 os:
   - linux
 julia:
-  - release
+  - 0.6
+  - nightly
 notifications:
   email: false
 script:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Once a `BenchmarkJob` is complete, the results are uploaded to the
 has its own directory for results. This directory contains the following items:
 
 - `report.md` is a markdown report that summarizes the job results
-- `data.tar.gz` contains raw timing data in JLD format. To untar this file, run
+- `data.tar.gz` contains raw timing data in JSON format. To untar this file, run
 `tar -xzvf data.tar.gz`. You can analyze this data using the
 [BenchmarkTools](https://github.com/JuliaCI/BaseBenchmarkReports) package.
 - `logs` is a directory containing the build logs and benchmark execution logs for the job.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,6 @@
-julia 0.4
-BenchmarkTools 0.0.7
+julia 0.6
+BenchmarkTools 0.2.0
 GitHub
 JSON
-JLD
 HttpCommon
 Compat 0.8.6

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,5 +2,5 @@ julia 0.6
 BenchmarkTools 0.2.0
 GitHub
 JSON
-HttpCommon
+HTTP
 Compat 0.8.6

--- a/src/Nanosoldier.jl
+++ b/src/Nanosoldier.jl
@@ -1,6 +1,6 @@
 module Nanosoldier
 
-import GitHub, BenchmarkTools, JSON, HttpCommon
+import GitHub, BenchmarkTools, JSON, HTTP
 
 using Compat
 

--- a/src/Nanosoldier.jl
+++ b/src/Nanosoldier.jl
@@ -1,10 +1,8 @@
 module Nanosoldier
 
-import GitHub, BenchmarkTools, JLD, JSON, HttpCommon
+import GitHub, BenchmarkTools, JSON, HttpCommon
 
 using Compat
-
-import Compat.UTF8String
 
 const TRIGGER = r"\@nanosoldier\s*`.*?`"
 const SHA_SEPARATOR = '@'
@@ -26,13 +24,13 @@ gitreset!(path) = cd(gitreset!, path)
 # error handling #
 ##################
 
-type NanosoldierError{E<:Exception} <: Exception
-    url::UTF8String
-    msg::UTF8String
+struct NanosoldierError{E<:Exception} <: Exception
+    url::String
+    msg::String
     err::E
 end
 
-NanosoldierError{E<:Exception}(msg, err::E) = NanosoldierError{E}("", msg, err)
+NanosoldierError(msg, err::E) where {E<:Exception} = NanosoldierError{E}("", msg, err)
 
 function Base.show(io::IO, err::NanosoldierError)
     print(io, "NanosoldierError: ", err.msg, ": ")

--- a/src/build.jl
+++ b/src/build.jl
@@ -2,15 +2,15 @@
 # BuildRef #
 ############
 
-type BuildRef
-    repo::UTF8String  # the build repo
-    sha::UTF8String   # the build + status SHA
-    vinfo::UTF8String # versioninfo() taken during the build
+mutable struct BuildRef
+    repo::String  # the build repo
+    sha::String   # the build + status SHA
+    vinfo::String # versioninfo() taken during the build
 end
 
 BuildRef(repo, sha) = BuildRef(repo, sha, "retrieving versioninfo() failed")
 
-function @compat(Base.:(==))(a::BuildRef, b::BuildRef)
+function Base.:(==)(a::BuildRef, b::BuildRef)
     return (a.repo == b.repo &&
             a.sha == b.sha &&
             a.vinfo == b.vinfo)

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,13 +1,12 @@
-
-immutable Config
-    user::UTF8String           # the OS username of the user running the server
+struct Config
+    user::String               # the OS username of the user running the server
     nodes::Vector{Int}         # the pids for the nodes on the cluster
     cpus::Vector{Int}          # the indices of the cpus per node
     auth::GitHub.Authorization # the GitHub authorization used to post statuses/reports
-    secret::UTF8String         # the GitHub secret used to validate webhooks
-    trackrepo::UTF8String      # the main Julia repo tracked by the server
-    reportrepo::UTF8String     # the repo to which result reports are posted
-    workdir::UTF8String        # the server's work directory
+    secret::String             # the GitHub secret used to validate webhooks
+    trackrepo::String          # the main Julia repo tracked by the server
+    reportrepo::String         # the repo to which result reports are posted
+    workdir::String            # the server's work directory
     testmode::Bool             # if true, jobs will run as test jobs
     function Config(user, nodes, cpus, auth, secret;
                     workdir = pwd(),

--- a/src/jobs/jobs.jl
+++ b/src/jobs/jobs.jl
@@ -6,7 +6,7 @@
 # - `Base.run(job::J)`: execute `job`
 # - `Base.summary(job::J)`: a short string identifying/describing `job`
 
-abstract AbstractJob
+abstract type AbstractJob end
 
 reply_status(job::AbstractJob, args...; kwargs...) = reply_status(submission(job), args...; kwargs...)
 reply_comment(job::AbstractJob, args...; kwargs...) = reply_comment(submission(job), args...; kwargs...)

--- a/src/server.jl
+++ b/src/server.jl
@@ -1,5 +1,4 @@
-
-immutable Server
+struct Server
     config::Config
     jobs::Vector{AbstractJob}
     listener::GitHub.CommentListener

--- a/src/server.jl
+++ b/src/server.jl
@@ -12,10 +12,10 @@ struct Server
         handle = (event, phrase) -> begin
             nodelog(config, 1, "received job submission with phrase $phrase")
             if event.kind == "issue_comment" && !(haskey(event.payload["issue"], "pull_request"))
-                return HttpCommon.Response(400, "nanosoldier jobs cannot be triggered from issue comments (only PRs or commits)")
+                return HTTP.Response(400, "nanosoldier jobs cannot be triggered from issue comments (only PRs or commits)")
             end
             if haskey(event.payload, "action") && !(in(event.payload["action"], ("created", "opened")))
-                return HttpCommon.Response(204, "no action taken (submission was from an edit, close, or delete)")
+                return HTTP.Response(204, "no action taken (submission was from an edit, close, or delete)")
             end
             submission = JobSubmission(config, event, phrase.match)
             addedjob = false
@@ -33,9 +33,9 @@ struct Server
             end
             if !(addedjob)
                 reply_status(submission, "error", "invalid job submission; check syntax")
-                HttpCommon.Response(400, "invalid job submission")
+                HTTP.Response(400, "invalid job submission")
             end
-            return HttpCommon.Response(202, "received job submission")
+            return HTTP.Response(202, "received job submission")
         end
 
         listener = GitHub.CommentListener(handle, TRIGGER;

--- a/test/report.md
+++ b/test/report.md
@@ -29,15 +29,15 @@ benchmark results remained invariant between builds).
 
 | ID | time ratio | memory ratio |
 |----|------------|--------------|
-| `["g","h","z"]` | 1.00 (60%)  | 5.00 (27%) :x: |
-| `["g","h",("y",1)]` | 2.00 (5%) :x: | 0.00 (3%) :white_check_mark: |
-| `["g","h",("y",2)]` | 0.50 (5%) :white_check_mark: | 1.00 (1%)  |
+| `["g", "h", "z"]` | 1.00 (60%)  | 5.00 (27%) :x: |
+| `["g", "h", ("y", 1)]` | 2.00 (5%) :x: | 0.00 (3%) :white_check_mark: |
+| `["g", "h", ("y", 2)]` | 0.50 (5%) :white_check_mark: | 1.00 (1%)  |
 
 ## Benchmark Group List
 
 Here's a list of all the benchmark groups executed by this job:
 
-- `["g","h"]`
+- `["g", "h"]`
 
 ## Version Info
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 import GitHub
-using Nanosoldier, Base.Test, Compat, BenchmarkTools
+using Nanosoldier, Compat, Compat.Test, BenchmarkTools
 using Nanosoldier: BuildRef, JobSubmission, Config, BenchmarkJob, AbstractJob
 using BenchmarkTools: TrialEstimate, Parameters
 
@@ -140,6 +140,6 @@ results["judged"] = BenchmarkTools.judge(results["primary"], results["against"])
 @test begin
     mdpath = joinpath(dirname(@__FILE__), "report.md")
     open(mdpath, "r") do file
-        readstring(file) == sprint(io -> Nanosoldier.printreport(io, job, results))
+        read(file, String) == sprint(io -> Nanosoldier.printreport(io, job, results))
     end
 end


### PR DESCRIPTION
In order to use the fancy new BenchmarkTools JSON-based serialization, we also need to update the Nanosoldier to use Julia 0.6.

I'm not intimately familiar with this code but the fact that benchmarks are loaded from JLD files as a `Dict` seems to be a pretty deep-seated assumption, so that will be a challenge to unravel completely.