### PR TITLE
Fixes + precompilation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
 BenchmarkTools 0.2.0
-GitHub
+GitHub 3.0.0
 JSON
 HTTP
 Compat 0.8.6

--- a/src/Nanosoldier.jl
+++ b/src/Nanosoldier.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module Nanosoldier
 
 import GitHub, BenchmarkTools, JSON, HTTP

--- a/src/Nanosoldier.jl
+++ b/src/Nanosoldier.jl
@@ -26,7 +26,7 @@ gitreset!(path) = cd(gitreset!, path)
 # error handling #
 ##################
 
-struct NanosoldierError{E<:Exception} <: Exception
+mutable struct NanosoldierError{E<:Exception} <: Exception
     url::String
     msg::String
     err::E


### PR DESCRIPTION
This should only be merged once https://github.com/JuliaLang/METADATA.jl/pull/11825 has been merged.

GitHub v3.0.0 replaced its dependency on HttpServer et al. with one on HTTP. Nanosoldier did the same in #38, but before GitHub was tagged, which caused conversion errors between Response objects from separate packages.

GitHub v3.0.0 also enabled precompilation for the module. GitHub was the only dependency of Nanosoldier that didn't have precompilation enabled, so with this change Nanosoldier is also able to precompile. Thus this PR also enables precompilation.

In #38, `NanosoldierError` was mistakenly changed from being declared as `type` to `struct`. The object is constructed piecemeal in the benchmark job code, so the type needs to be mutable.