### PR TITLE
Record error if no daily is found but don't rethrow

### DIFF
--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -211,7 +211,7 @@ function Base.run(job::BenchmarkJob)
                     found_previous_date && (results["previous_date"] = check_date)
                     i += 1
                 end
-                !(found_previous_date) && error("didn't find previous daily build data in the past 31 days")
+                found_previous_date || nodelog(cfg, node, "didn't find previous daily build data in the past 31 days")
             catch err
                 rethrow(NanosoldierError("encountered error when retrieving old daily build data", err))
             end


### PR DESCRIPTION
When running the daily jobs, primary data is being generated, but there is no prior JSON data to compare against, so an error is thrown. What we should be doing is recording the error but letting the build proceed so that the primary results are saved and can be compared against in the next daily run.