### PR TITLE
Remove use of now in benchscript

### DIFF
--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -309,6 +309,9 @@ function execute_benchmarks!(job::BenchmarkJob, whichbuild::Symbol)
 
     open(jlscriptpath, "w") do file
         println(file, """
+                      using Compat
+                      using Compat.Dates # needed for `now`
+
                       println(now(), " | starting benchscript.jl (STDOUT/STDERR will be redirected to the result folder)")
                       benchout = open(\"$(benchout)\", "w"); redirect_stdout(benchout)
                       bencherr = open(\"$(bencherr)\", "w"); redirect_stderr(bencherr)


### PR DESCRIPTION
Just when you think you've worked around Dates moving to the stdlib everywhere, you find that the seemingly innocuous `now` is being written to the benchmarking script file for every job.