### PR TITLE
Updates for Julia 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ language: julia
 os:
   - linux
 julia:
-  - 0.6
+  - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false
-script:
-    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.clone(pwd()); Pkg.build("Nanosoldier"); Pkg.test("Nanosoldier")'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,5 @@
-julia 0.6
-BenchmarkTools 0.2.0
-GitHub 3.0.0
+julia 0.7
+BenchmarkTools 0.4.0
+GitHub 5.0.0
 JSON
 HTTP
-Compat 0.37.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,19 @@
 environment:
+environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
 
 branches:
   only:
@@ -17,18 +27,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"Nanosoldier\"); Pkg.build(\"Nanosoldier\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"Nanosoldier\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/bin/setup_base_ci.jl
+++ b/bin/setup_base_ci.jl
@@ -1,8 +1,6 @@
-if VERSION >= v"0.7.0-DEV.2954"
-    using Distributed
-end
+using Distributed
 
-nodes = addprocs(["nanosoldier7", "nanosoldier8"], exeflags=["--compilecache=no", "--precompiled=no"])
+nodes = addprocs(["nanosoldier7", "nanosoldier8"])
 
 import Nanosoldier, GitHub
 

--- a/bin/setup_test_ci.jl
+++ b/bin/setup_test_ci.jl
@@ -1,8 +1,6 @@
-if VERSION >= v"0.7.0-DEV.2954"
-    using Distributed
-end
+using Distributed
 
-nodes = addprocs(["nanosoldier6"], exeflags=["--compilecache=no", "--precompiled=no"])
+nodes = addprocs(["nanosoldier6"])
 
 import Nanosoldier, GitHub
 

--- a/bin/submit_daily_job.jl
+++ b/bin/submit_daily_job.jl
@@ -2,11 +2,11 @@ import GitHub
 
 auth = GitHub.authenticate(ENV["GITHUB_AUTH"])
 repo = "JuliaLang/julia"
-sha = get(get(GitHub.branch(repo, "master").commit).sha)
+sha = GitHub.branch(repo, "master").commit.sha
 message = """
           Executing the daily benchmark build, I will reply here when finished:
 
           @nanosoldier `runbenchmarks(ALL, isdaily = true)`
           """
 
-GitHub.create_comment(repo, sha, :commit, auth = auth, params = Dict("body" => message))
+GitHub.create_comment(repo, sha, :commit, auth=auth, params=Dict("body" => message))

--- a/src/Nanosoldier.jl
+++ b/src/Nanosoldier.jl
@@ -2,10 +2,8 @@ __precompile__()
 
 module Nanosoldier
 
+using Dates, Distributed, Printf
 import GitHub, BenchmarkTools, JSON, HTTP
-
-using Compat
-using Compat.Dates
 
 const TRIGGER = r"\@nanosoldier\s*`.*?`"
 const SHA_SEPARATOR = '@'
@@ -15,13 +13,7 @@ const BRANCH_SEPARATOR = ':'
 # utility functions #
 #####################
 
-if VERSION < v"0.7.0-DEV.2437"
-    const parsecode = Base.parse
-else
-    const parsecode = Meta.parse
-end
-
-snip(str, len) = length(str) > len ? str[1:len] : str
+snip(str, len) = str[1:min(len, end)]
 snipsha(sha) = snip(sha, 7)
 
 gitclone!(repo, path) = run(`git clone git@github.com:$(repo).git $(path)`)

--- a/src/config.jl
+++ b/src/config.jl
@@ -8,13 +8,14 @@ struct Config
     reportrepo::String         # the repo to which result reports are posted
     workdir::String            # the server's work directory
     testmode::Bool             # if true, jobs will run as test jobs
+
     function Config(user, nodes, cpus, auth, secret;
                     workdir = pwd(),
                     trackrepo = "JuliaLang/julia",
                     reportrepo = "JuliaCI/BaseBenchmarkReports",
                     testmode = false)
-        @assert !(isempty(nodes)) "need at least one node to work on"
-        @assert !(isempty(cpus)) "need at least one cpu per node to work on"
+        isempty(nodes) && throw(ArgumentError("need at least one node to work on"))
+        isempty(cpus) && throw(ArgumentError("need at least one cpu per node to work on"))
         return new(user, nodes, cpus, auth, secret, trackrepo,
                    reportrepo, workdir, testmode)
     end
@@ -29,7 +30,7 @@ reportrepo(config::Config) = config.reportrepo
 # the local directory of the report repository
 reportdir(config::Config) = joinpath(workdir(config), split(reportrepo(config), "/")[2])
 
-persistdir!(path) = (!(isdir(path)) && mkdir(path); return path)
+persistdir!(path) = (isdir(path) || mkdir(path); return path)
 
 function persistdir!(config::Config)
     persistdir!(workdir(config))


### PR DESCRIPTION
The server will now be able to run on 0.7 and newer, and I'll set up the production server to run on 1.0. Other notable changes:
* `Union`s are now used instead of `Nullable`s, in keeping with GitHub.jl
* Precompilation on worker nodes is no longer disabled
* Building Julia will now use ccache to improve the overall run time
* We should get fewer "too many open files" errors, if my fix is correct (it's otherwise harmless)
* There's a lot of logic in place to make testing against older Julia versions (e.g. 0.6) still work, and it's ugly