### PR TITLE
Make Nanosoldier emit more information into the server log

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -41,9 +41,15 @@ function persistdir!(config::Config)
     end
 end
 
-function nodelog(config::Config, node, message)
+function nodelog(config::Config, node, message; error=nothing)
+    time = now()
+    if error !== nothing
+        @error "[Node $node | $time]: Encountered error: $message" exception=error
+    else
+        @info "[Node $node | $time]: $message"
+    end
     persistdir!(workdir(config))
     open(joinpath(workdir(config), "node$(node).log"), "a") do file
-        println(file, now(), " | ", node, " | ", message)
+        println(file, time, " | ", node, " | ", message)
     end
 end

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -151,7 +151,9 @@ function retrieve_daily_data!(results, key, cfg, date)
                     found_previous_date = true
                 end
             catch err
-                nodelog(cfg, myid(), string("encountered error when retrieving daily data: ", sprint(showerror, err)))
+                nodelog(cfg, myid(),
+                        "encountered error when retrieving daily data: " * sprint(showerror, err),
+                        error=(err, stacktrace(catch_backtrace())))
             finally
                 isdir(datapath) && rm(datapath, recursive=true)
             end


### PR DESCRIPTION
This change is a bit iffy as it might be the equivalent of barfing information violently into a REPL session for everything that happens on each node, so... we'll see.