### PR TITLE
Use at-everywhere for loading on the workers

### DIFF
--- a/bin/setup_base_ci.jl
+++ b/bin/setup_base_ci.jl
@@ -1,8 +1,9 @@
 using Distributed
+import Nanosoldier, GitHub
 
 nodes = addprocs(["nanosoldier7", "nanosoldier8"])
 
-import Nanosoldier, GitHub
+@everywhere using Nanosoldier
 
 cpus = [1,2,3]
 auth = GitHub.authenticate(ENV["GITHUB_AUTH"])

--- a/bin/setup_test_ci.jl
+++ b/bin/setup_test_ci.jl
@@ -1,8 +1,9 @@
 using Distributed
+import Nanosoldier, GitHub
 
 nodes = addprocs(["nanosoldier6"])
 
-import Nanosoldier, GitHub
+@everywhere using Nanosoldier
 
 cpus = [1,2,3]
 auth = GitHub.authenticate(ENV["GITHUB_AUTH"])

--- a/src/config.jl
+++ b/src/config.jl
@@ -44,9 +44,9 @@ end
 function nodelog(config::Config, node, message; error=nothing)
     time = now()
     if error !== nothing
-        @error "[Node $node | $time]: Encountered error: $message" exception=error
+        @error "Encountered error: $message" exception=error node=node time=time
     else
-        @info "[Node $node | $time]: $message"
+        @info message node=node time=time
     end
     persistdir!(workdir(config))
     open(joinpath(workdir(config), "node$(node).log"), "a") do file


### PR DESCRIPTION
Pretty much a blind guess but it seems like Nanosoldier isn't being properly loaded on the workers, so let's load it right after `addprocs`ing them.