### PR TITLE
Use Pkg.develop instead of Pkg.add on 0.7+

### DIFF
--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -274,7 +274,7 @@ function execute_benchmarks!(job::BenchmarkJob, whichbuild::Symbol)
                 VERSION >= v"0.7.0-DEV.3656" && using Pkg
                 url = "https://github.com/JuliaCI/BaseBenchmarks.jl"
                 if VERSION >= v"0.7.0-DEV.5183"
-                    Pkg.add(PackageSpec(name="BaseBenchmarks", url=url))
+                    Pkg.develop(PackageSpec(name="BaseBenchmarks", url=url))
                 else
                     Pkg.clone(url)
                 end


### PR DESCRIPTION
We apparently are trying to do some Git operations on BaseBenchmarks, but we don't actually have the full Git clone of it when using `Pkg.add`. `Pkg.develop` solves this and will give us the whole shebang.