### PR TITLE
Everything we call by name needs to be `Pkg.add`ed

### DIFF
--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -278,6 +278,8 @@ function execute_benchmarks!(job::BenchmarkJob, whichbuild::Symbol)
                 else
                     Pkg.clone(url)
                 end
+                # These are referenced by name so they need to be added explicitly
+                foreach(Pkg.add, ("Compat", "BenchmarkTools", "JSON"))
             '
             ```)
     catch


### PR DESCRIPTION
This includes Compat, BenchmarkTools, and JSON. Otherwise Julia complains that it can't find those packages.