### PR TITLE
Fix the incorrect use of redirect_std* functions

### DIFF
--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -346,10 +346,10 @@ function execute_benchmarks!(job::BenchmarkJob, whichbuild::Symbol)
                       println(now(), " | starting benchscript.jl (STDOUT/STDERR will be redirected to the result folder)")
                       benchout = open(\"$(benchout)\", "w")
                       oldout = stdout
-                      rdout, wrout = redirect_stdout(benchout)
+                      redirect_stdout(benchout)
                       bencherr = open(\"$(bencherr)\", "w")
                       olderr = stderr
-                      rderr, wrerr = redirect_stderr(bencherr)
+                      redirect_stderr(bencherr)
 
                       # ensure we don't leak file handles when something goes wrong
                       try
@@ -378,10 +378,8 @@ function execute_benchmarks!(job::BenchmarkJob, whichbuild::Symbol)
                       finally
                           redirect_stdout(oldout)
                           close(benchout)
-                          close(wrout)
                           redirect_stderr(olderr)
                           close(bencherr)
-                          close(wrerr)
                       end
                       """)
     end


### PR DESCRIPTION
The code as implemented in #61 assumes that `redirect_std*` returns a tuple. That is only true when the function is given no arguments. When given a single `IOStream` as an argument, the function does a pointer store then returns the input stream. That causes an error when using the destructuring assignment syntax (no method matching `iterate(::IOStream)`).

This change mostly reverts #61, except it keeps the redirects back to the original STDOUT/STDERR streams.