### PR TITLE
Don't use BinaryBuilder for LLVM

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -50,7 +50,8 @@ function build_julia!(config::Config, build::BuildRef, logpath, prnumber::Union{
     errfile = joinpath(logpath, string(logname, ".err"))
 
     # run the build
-    run(pipeline(`make -j$(length(config.cpus)) USECCACHE=1`, stdout=outfile, stderr=errfile))
+    run(pipeline(`make -j$(length(config.cpus)) USECCACHE=1 USE_BINARYBUILDER_LLVM=0`,
+                 stdout=outfile, stderr=errfile))
     cd(workdir(config))
     return builddir
 end


### PR DESCRIPTION
The base system compiler on the current Nanosoldier machines is GCC 4, which doesn't use CXX11 ABI strings. See discussion in https://github.com/JuliaLang/julia/commit/a46e37bcc5a32860bc210ee16dc61dc10b567dbd.