### PR TITLE
Add a PkgEvalJob based on NewPkgEval

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ language: julia
 os:
   - linux
 julia:
-  - 0.7
-  - 1.0
+  - 1.3
   - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -40,9 +40,9 @@ version = "0.5.8"
 
 [[CategoricalArrays]]
 deps = ["Compat", "DataAPI", "Future", "JSON", "Missings", "Printf", "Reexport", "Statistics", "Unicode"]
-git-tree-sha1 = "9127b0c2ee1bfd810921dd688dd8d73be1d9fb57"
+git-tree-sha1 = "7c4419347d724a057b5a550078f8ff4cdfdeedf6"
 uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-version = "0.7.5"
+version = "0.7.6"
 
 [[CodecZlib]]
 deps = ["BinaryProvider", "Libdl", "TranscodingStreams"]
@@ -92,9 +92,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[Feather]]
 deps = ["Arrow", "CategoricalArrays", "DataFrames", "Dates", "FlatBuffers", "Mmap", "Tables"]
-git-tree-sha1 = "a963f89bc16735af00cd28ac60d4145cd7fe2abd"
+git-tree-sha1 = "f00ed0cadaa2ff0ee31340482f3fbf9321ad2499"
 uuid = "becb17da-46f6-5d3c-ad1b-1c5fe96bc73c"
-version = "0.5.3"
+version = "0.5.4"
 
 [[FileIO]]
 deps = ["Pkg"]
@@ -162,9 +162,9 @@ version = "1.0.0"
 
 [[JLD2]]
 deps = ["CodecZlib", "DataStructures", "FileIO", "Mmap", "Pkg", "Printf", "UUIDs"]
-git-tree-sha1 = "2c1a6d672f2b85a520d59e63851bc67226b06ba8"
+git-tree-sha1 = "5deae9f0745ef505ed155a0029629cf08502ccab"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.1.10"
+version = "0.1.11"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -229,14 +229,14 @@ uuid = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
 version = "1.0.0"
 
 [[Mux]]
-deps = ["AssetRegistry", "Base64", "HTTP", "Hiccup", "Lazy", "Pkg", "Sockets", "Test", "WebSockets"]
-git-tree-sha1 = "5b41f03d63400c290bab4e1a49fb9ac36de1084a"
+deps = ["AssetRegistry", "Base64", "HTTP", "Hiccup", "Lazy", "Pkg", "Sockets", "WebSockets"]
+git-tree-sha1 = "3621676e7f711aca14d783d1bff9ac379d9df6b7"
 uuid = "a975b10e-0019-58db-a62f-e48ff68538c9"
-version = "0.7.0"
+version = "0.7.1"
 
 [[NewPkgEval]]
 deps = ["BinaryBuilder", "DataFrames", "Dates", "LibGit2", "Mustache", "Pkg", "ProgressMeter", "Random", "SHA"]
-git-tree-sha1 = "abbd186064aeda3f74fef3010fe0847cdd081d36"
+git-tree-sha1 = "46e1c4b414d11331e590e5c7d86bb5a46b96dcb4"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaComputing/NewPkgEval.jl"
 uuid = "9f2e2246-6dce-11e8-3d98-4b291446da6e"
@@ -374,10 +374,10 @@ deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[TimeToLive]]
-deps = ["Dates", "Test"]
-git-tree-sha1 = "43defcaf72b89b047f11b778cd83b71ac3e418b0"
+deps = ["Dates"]
+git-tree-sha1 = "1f1389007d16385ec02e497bef6c2caffba99b65"
 uuid = "37f0c46e-897f-50ef-b453-b26c3eed3d6c"
-version = "0.2.0"
+version = "0.3.0"
 
 [[TranscodingStreams]]
 deps = ["Random", "Test"]
@@ -399,10 +399,16 @@ uuid = "104b5d7c-a370-577a-8038-80a2059c5097"
 version = "1.5.2"
 
 [[ZMQ]]
-deps = ["BinaryProvider", "FileWatching", "Libdl", "Sockets", "Test"]
-git-tree-sha1 = "34e7ac2d1d59d19d0e86bde99f1f02262bfa1613"
+deps = ["FileWatching", "Sockets", "ZeroMQ_jll"]
+git-tree-sha1 = "adb2d52aa12c8284da12714f35d2b21fc3d5b2bb"
 uuid = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
-version = "1.0.0"
+version = "1.2.0"
+
+[[ZeroMQ_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "a22171d073707dbcc99a1dfefc2c6e823beb9664"
+uuid = "8f1865be-045e-5c20-9c9f-bfbfb0764568"
+version = "4.3.1+0"
 
 [[ghr_jll]]
 deps = ["Libdl", "Pkg"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -238,7 +238,7 @@ version = "0.7.0"
 
 [[NewPkgEval]]
 deps = ["BinaryBuilder", "DataFrames", "Dates", "LibGit2", "Mustache", "Pkg", "ProgressMeter", "Random", "SHA"]
-git-tree-sha1 = "75398fa37a8d7d580a0d1b9a4704ec5492c2b137"
+git-tree-sha1 = "385a7e4e196fa689fd8de5034aa52f8ebe917fa9"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaComputing/NewPkgEval.jl"
 uuid = "9f2e2246-6dce-11e8-3d98-4b291446da6e"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -28,11 +28,9 @@ version = "0.4.3"
 
 [[BinaryBuilder]]
 deps = ["Base64", "Dates", "GitHub", "HTTP", "InteractiveUtils", "JLD2", "JSON", "LibGit2", "Libdl", "MbedTLS", "ObjectFile", "Pkg", "PkgLicenses", "ProgressMeter", "REPL", "Random", "Registrator", "RegistryTools", "SHA", "Sockets", "ghr_jll"]
-git-tree-sha1 = "ebff39652f362552d76b2565d363c36a993a1a70"
-repo-rev = "master"
-repo-url = "https://github.com/JuliaPackaging/BinaryBuilder.jl.git"
+git-tree-sha1 = "777ceefb0b33ff663d373a74b28ca048237b985b"
 uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
-version = "0.2.0"
+version = "0.2.1"
 
 [[BinaryProvider]]
 deps = ["Libdl", "SHA"]
@@ -41,10 +39,10 @@ uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 version = "0.5.8"
 
 [[CategoricalArrays]]
-deps = ["Compat", "DataAPI", "Future", "JSON", "Missings", "Printf", "Reexport", "Unicode"]
-git-tree-sha1 = "9c3fd1ebb503d271943c4ea94332d55ea900c9cb"
+deps = ["Compat", "DataAPI", "Future", "JSON", "Missings", "Printf", "Reexport", "Statistics", "Unicode"]
+git-tree-sha1 = "9127b0c2ee1bfd810921dd688dd8d73be1d9fb57"
 uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-version = "0.7.4"
+version = "0.7.5"
 
 [[CodecZlib]]
 deps = ["BinaryProvider", "Libdl", "TranscodingStreams"]
@@ -71,9 +69,9 @@ version = "0.19.4"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "a1b652fb77ae8ca7ea328fa7ba5aa151036e5c10"
+git-tree-sha1 = "f784254f428fb8fd7ac15982e5862a38a44523d3"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.6"
+version = "0.17.7"
 
 [[DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -100,9 +98,9 @@ version = "0.5.3"
 
 [[FileIO]]
 deps = ["Pkg"]
-git-tree-sha1 = "6c976460b85527d22d979682222d36767d95e27f"
+git-tree-sha1 = "74585bf1f7ed7259e166011e89f49363d7fa89a6"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-version = "1.1.0"
+version = "1.2.1"
 
 [[FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
@@ -164,9 +162,9 @@ version = "1.0.0"
 
 [[JLD2]]
 deps = ["CodecZlib", "DataStructures", "FileIO", "Mmap", "Pkg", "Printf", "UUIDs"]
-git-tree-sha1 = "0193ef8c75ce70584198b95b4a48f9ec0c49ffa8"
+git-tree-sha1 = "2c1a6d672f2b85a520d59e63851bc67226b06ba8"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.1.9"
+version = "0.1.10"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -238,7 +236,7 @@ version = "0.7.0"
 
 [[NewPkgEval]]
 deps = ["BinaryBuilder", "DataFrames", "Dates", "LibGit2", "Mustache", "Pkg", "ProgressMeter", "Random", "SHA"]
-git-tree-sha1 = "385a7e4e196fa689fd8de5034aa52f8ebe917fa9"
+git-tree-sha1 = "abbd186064aeda3f74fef3010fe0847cdd081d36"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaComputing/NewPkgEval.jl"
 uuid = "9f2e2246-6dce-11e8-3d98-4b291446da6e"
@@ -275,7 +273,7 @@ uuid = "fa939f87-e72e-5be4-a000-7fc836dbe307"
 version = "1.1.0"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[PkgLicenses]]
@@ -285,9 +283,10 @@ uuid = "fc669557-7ec9-5e45-bca9-462afbc28879"
 version = "0.2.0"
 
 [[PooledArrays]]
-git-tree-sha1 = "6e8c38927cb6e9ae144f7277c753714861b27d14"
+deps = ["DataAPI"]
+git-tree-sha1 = "b1333d4eced1826e15adbdf01a4ecaccca9d353c"
 uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
-version = "0.5.2"
+version = "0.5.3"
 
 [[Printf]]
 deps = ["Unicode"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,412 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Arrow]]
+deps = ["CategoricalArrays", "Dates"]
+git-tree-sha1 = "c86df6ed41b3bd192d663e5e0e7cac0d11fd4375"
+uuid = "69666777-d1a9-59fb-9406-91d4454c9d45"
+version = "0.2.4"
+
+[[AssetRegistry]]
+deps = ["Distributed", "JSON", "Pidfile", "SHA", "Test"]
+git-tree-sha1 = "b25e88db7944f98789130d7b503276bc34bc098e"
+uuid = "bf4720bc-e11a-5d0c-854e-bdca1663c893"
+version = "0.1.0"
+
+[[AutoHashEquals]]
+git-tree-sha1 = "45bb6705d93be619b81451bb2006b7ee5d4e4453"
+uuid = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
+version = "0.2.0"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BenchmarkTools]]
+deps = ["JSON", "Printf", "Statistics"]
+git-tree-sha1 = "90b73db83791c5f83155016dd1cc1f684d4e1361"
+uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+version = "0.4.3"
+
+[[BinaryBuilder]]
+deps = ["Base64", "Dates", "GitHub", "HTTP", "InteractiveUtils", "JLD2", "JSON", "LibGit2", "Libdl", "MbedTLS", "ObjectFile", "Pkg", "PkgLicenses", "ProgressMeter", "REPL", "Random", "Registrator", "RegistryTools", "SHA", "Sockets", "ghr_jll"]
+git-tree-sha1 = "ebff39652f362552d76b2565d363c36a993a1a70"
+repo-rev = "master"
+repo-url = "https://github.com/JuliaPackaging/BinaryBuilder.jl.git"
+uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
+version = "0.2.0"
+
+[[BinaryProvider]]
+deps = ["Libdl", "SHA"]
+git-tree-sha1 = "5b08ed6036d9d3f0ee6369410b830f8873d4024c"
+uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+version = "0.5.8"
+
+[[CategoricalArrays]]
+deps = ["Compat", "DataAPI", "Future", "JSON", "Missings", "Printf", "Reexport", "Unicode"]
+git-tree-sha1 = "9c3fd1ebb503d271943c4ea94332d55ea900c9cb"
+uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+version = "0.7.4"
+
+[[CodecZlib]]
+deps = ["BinaryProvider", "Libdl", "TranscodingStreams"]
+git-tree-sha1 = "05916673a2627dd91b4969ff8ba6941bc85a960e"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.6.0"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "ed2c4abadf84c53d9e58510b5fc48912c2336fbb"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "2.2.0"
+
+[[DataAPI]]
+git-tree-sha1 = "674b67f344687a88310213ddfa8a2b3c76cc4252"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.1.0"
+
+[[DataFrames]]
+deps = ["CategoricalArrays", "Compat", "DataAPI", "InvertedIndices", "IteratorInterfaceExtensions", "Missings", "PooledArrays", "Printf", "REPL", "Reexport", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
+git-tree-sha1 = "271528230c65a4517522e2968c3deed76b92b998"
+uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+version = "0.19.4"
+
+[[DataStructures]]
+deps = ["InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "a1b652fb77ae8ca7ea328fa7ba5aa151036e5c10"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.17.6"
+
+[[DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[Feather]]
+deps = ["Arrow", "CategoricalArrays", "DataFrames", "Dates", "FlatBuffers", "Mmap", "Tables"]
+git-tree-sha1 = "a963f89bc16735af00cd28ac60d4145cd7fe2abd"
+uuid = "becb17da-46f6-5d3c-ad1b-1c5fe96bc73c"
+version = "0.5.3"
+
+[[FileIO]]
+deps = ["Pkg"]
+git-tree-sha1 = "6c976460b85527d22d979682222d36767d95e27f"
+uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+version = "1.1.0"
+
+[[FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+
+[[FlatBuffers]]
+deps = ["Parameters", "Test"]
+git-tree-sha1 = "8582924ac52011d08da9cf1e67f13a71dbbc2594"
+uuid = "53afe959-3a16-52fa-a8da-cf864710bae9"
+version = "0.5.4"
+
+[[Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+
+[[GitForge]]
+deps = ["Dates", "HTTP", "JSON2"]
+git-tree-sha1 = "4469573ba6e4c262ba3c3018de2166c063ec5c2d"
+uuid = "8f6bce27-0656-5410-875b-07a5572985df"
+version = "0.1.5"
+
+[[GitHub]]
+deps = ["Base64", "Dates", "HTTP", "JSON", "MbedTLS", "Sockets"]
+git-tree-sha1 = "477818ab174a14d4730b3d15ac8719dbc98555d2"
+uuid = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
+version = "5.1.3"
+
+[[HTTP]]
+deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets"]
+git-tree-sha1 = "5c49dab19938b119fe204fd7d7e8e174f4e9c68b"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "0.8.8"
+
+[[Hiccup]]
+deps = ["MacroTools", "Test"]
+git-tree-sha1 = "6187bb2d5fcbb2007c39e7ac53308b0d371124bd"
+uuid = "9fb69e20-1954-56bb-a84f-559cc56a8ff7"
+version = "0.2.2"
+
+[[IniFile]]
+deps = ["Test"]
+git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
+uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
+version = "0.5.0"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[InvertedIndices]]
+deps = ["Test"]
+git-tree-sha1 = "15732c475062348b0165684ffe28e85ea8396afc"
+uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
+version = "1.0.0"
+
+[[IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[JLD2]]
+deps = ["CodecZlib", "DataStructures", "FileIO", "Mmap", "Pkg", "Printf", "UUIDs"]
+git-tree-sha1 = "0193ef8c75ce70584198b95b4a48f9ec0c49ffa8"
+uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+version = "0.1.9"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "b34d7cef7b337321e97d22242c3c2b91f476748e"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.0"
+
+[[JSON2]]
+deps = ["Dates", "Parsers", "Test"]
+git-tree-sha1 = "6cbbbab27d9411946725f5d5c91e8b8fb5f7d5db"
+uuid = "2535ab7d-5cd8-5a07-80ac-9b1792aadce3"
+version = "0.3.1"
+
+[[Lazy]]
+deps = ["MacroTools"]
+git-tree-sha1 = "ead48f10ad295afe72046ab0f2b9d704466452a0"
+uuid = "50d2b5c4-7a5e-59d5-8109-a42b560f39c0"
+version = "0.14.0"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[MacroTools]]
+deps = ["DataStructures", "Markdown", "Random"]
+git-tree-sha1 = "e2fc7a55bb2224e203bbd8b59f72b91323233458"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.3"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MbedTLS]]
+deps = ["BinaryProvider", "Dates", "Libdl", "Random", "Sockets"]
+git-tree-sha1 = "85f5947b53c8cfd53ccfa3f4abae31faa22c2181"
+uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
+version = "0.7.0"
+
+[[Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "de0a5ce9e5289f27df672ffabef4d1e5861247d5"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "0.4.3"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Mustache]]
+deps = ["Printf", "Tables"]
+git-tree-sha1 = "e06eef2abee113c49695f5347668e15d4c02978a"
+uuid = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
+version = "1.0.0"
+
+[[Mux]]
+deps = ["AssetRegistry", "Base64", "HTTP", "Hiccup", "Lazy", "Pkg", "Sockets", "Test", "WebSockets"]
+git-tree-sha1 = "5b41f03d63400c290bab4e1a49fb9ac36de1084a"
+uuid = "a975b10e-0019-58db-a62f-e48ff68538c9"
+version = "0.7.0"
+
+[[NewPkgEval]]
+deps = ["BinaryBuilder", "DataFrames", "Dates", "LibGit2", "Mustache", "Pkg", "ProgressMeter", "Random", "SHA"]
+git-tree-sha1 = "75398fa37a8d7d580a0d1b9a4704ec5492c2b137"
+repo-rev = "master"
+repo-url = "https://github.com/JuliaComputing/NewPkgEval.jl"
+uuid = "9f2e2246-6dce-11e8-3d98-4b291446da6e"
+version = "0.1.0"
+
+[[ObjectFile]]
+deps = ["Reexport", "StructIO", "Test"]
+git-tree-sha1 = "310770e17bb9c4142b9f0b8d2d30dd7bd1c13a73"
+uuid = "d8793406-e978-5875-9003-1fc021f44a92"
+version = "0.3.3"
+
+[[OrderedCollections]]
+deps = ["Random", "Serialization", "Test"]
+git-tree-sha1 = "c4c13474d23c60d20a67b217f1d7f22a40edf8f1"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.1.0"
+
+[[Parameters]]
+deps = ["OrderedCollections"]
+git-tree-sha1 = "b62b2558efb1eef1fa44e4be5ff58a515c287e38"
+uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+version = "0.12.0"
+
+[[Parsers]]
+deps = ["Dates", "Test"]
+git-tree-sha1 = "0139ba59ce9bc680e2925aec5b7db79065d60556"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "0.3.10"
+
+[[Pidfile]]
+deps = ["FileWatching", "Test"]
+git-tree-sha1 = "1ffd82728498b5071cde851bbb7abd780d4445f3"
+uuid = "fa939f87-e72e-5be4-a000-7fc836dbe307"
+version = "1.1.0"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[PkgLicenses]]
+deps = ["Test"]
+git-tree-sha1 = "0af826be249c6751a3e783c07b8cd3034f508943"
+uuid = "fc669557-7ec9-5e45-bca9-462afbc28879"
+version = "0.2.0"
+
+[[PooledArrays]]
+git-tree-sha1 = "6e8c38927cb6e9ae144f7277c753714861b27d14"
+uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
+version = "0.5.2"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[ProgressMeter]]
+deps = ["Distributed", "Printf"]
+git-tree-sha1 = "ea1f4fa0ff5e8b771bf130d87af5b7ef400760bd"
+uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
+version = "1.2.0"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Reexport]]
+deps = ["Pkg"]
+git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "0.2.0"
+
+[[Registrator]]
+deps = ["AutoHashEquals", "Base64", "Dates", "Distributed", "FileWatching", "GitForge", "GitHub", "HTTP", "JSON", "LibGit2", "Logging", "MbedTLS", "Mustache", "Mux", "Pkg", "Serialization", "Sockets", "TimeToLive", "UUIDs", "ZMQ"]
+git-tree-sha1 = "0dc917d3370553aebe50b80bdff9142e665a021c"
+uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
+version = "1.0.0"
+
+[[RegistryTools]]
+deps = ["AutoHashEquals", "LibGit2", "Pkg", "UUIDs"]
+git-tree-sha1 = "f9333ef8731c656815f3cc52cf73e2d56c4de6f4"
+uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
+version = "1.1.0"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SortingAlgorithms]]
+deps = ["DataStructures", "Random", "Test"]
+git-tree-sha1 = "03f5898c9959f8115e30bc7226ada7d0df554ddd"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "0.3.1"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[StructIO]]
+deps = ["Test"]
+git-tree-sha1 = "010dc73c7146869c042b49adcdb6bf528c12e859"
+uuid = "53d494c1-5632-5724-8f4c-31dff12d585f"
+version = "0.3.0"
+
+[[TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "b1ad568ba658d8cbb3b892ed5380a6f3e781a81e"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.0"
+
+[[Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
+git-tree-sha1 = "aaed7b3b00248ff6a794375ad6adf30f30ca5591"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "0.2.11"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[TimeToLive]]
+deps = ["Dates", "Test"]
+git-tree-sha1 = "43defcaf72b89b047f11b778cd83b71ac3e418b0"
+uuid = "37f0c46e-897f-50ef-b453-b26c3eed3d6c"
+version = "0.2.0"
+
+[[TranscodingStreams]]
+deps = ["Random", "Test"]
+git-tree-sha1 = "7c53c35547de1c5b9d46a4797cf6d8253807108c"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.9.5"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[WebSockets]]
+deps = ["Base64", "Dates", "Distributed", "HTTP", "Logging", "Random", "Sockets", "Test"]
+git-tree-sha1 = "13f763d38c7a05688938808b49cb29b18b60c8c8"
+uuid = "104b5d7c-a370-577a-8038-80a2059c5097"
+version = "1.5.2"
+
+[[ZMQ]]
+deps = ["BinaryProvider", "FileWatching", "Libdl", "Sockets", "Test"]
+git-tree-sha1 = "34e7ac2d1d59d19d0e86bde99f1f02262bfa1613"
+uuid = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
+version = "1.0.0"
+
+[[ghr_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "a842af97ca0010aedcfd765a4dfcfe403732a929"
+uuid = "07c12ed4-43bc-5495-8a2a-d5838ef8d533"
+version = "0.13.0+0"

--- a/Project.toml
+++ b/Project.toml
@@ -4,18 +4,22 @@ version = "0.1.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+Feather = "becb17da-46f6-5d3c-ad1b-1c5fe96bc73c"
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+NewPkgEval = "9f2e2246-6dce-11e8-3d98-4b291446da6e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-julia = "0.7"
 BenchmarkTools = "0.4"
+DataFrames = "0.19"
 GitHub = "5"
+julia = "0.7, 1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,24 @@
+name = "Nanosoldier"
+uuid = "89f34f1a-2e6b-52eb-a20f-77051b03b735"
+version = "0.1.0"
+
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[compat]
+julia = "0.7"
+BenchmarkTools = "0.4"
+GitHub = "5"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 NewPkgEval = "9f2e2246-6dce-11e8-3d98-4b291446da6e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,40 @@ against the head commit of my fork's branch.
 @nanosoldier `runbenchmarks(ALL, vs = "ararslan/julia:mybranch")`
 ```
 
+### `PkgEvalJob`
+
+#### Execution Cycle
+
+A `PkgEvalJob` has the following execution cycle:
+
+1. Pull in the JuliaLang/julia repository and build the commit specified by the context of the trigger phrase.
+2. Using the new Julia build, test the packages from the [General](https://github.com/JuliaRegistries/General) registry as specified by the trigger phrase.
+3. If the trigger phrase specifies a commit to compare against, build that version of Julia and perform step 2 using the comparison build.
+4. Upload a markdown report to the [BaseBenchmarkReports](https://github.com/JuliaCI/BaseBenchmarkReports) repository.
+
+#### Trigger Syntax
+
+A `PkgEvalJob` is triggered with the following syntax:
+
+```
+@nanosoldier `runtests(package_selection, vs = "ref")`
+```
+
+The package selection argument is used to decide which packages to test. It should be a list of package names, e.g. `["Example"]`, that will be looked up in the registry. Additionally, you can test all packages in the registry by using the keyword `ALL`, e.g. `runtests(ALL)`.
+
+The `vs` keyword argument is optional, and is used to determine whether or not the comparison step (step 3 above) is performed. Its syntax is identical to the `BenchmarkJob` `vs` keyword argument.
+
+#### Benchmark Results
+
+Once a `PkgEvalJob` is complete, the results are uploaded to the
+[BaseBenchmarkReports](https://github.com/JuliaCI/BaseBenchmarkReports) repository. Each job
+has its own directory for results. This directory contains the following items:
+
+- `report.md` is a markdown report that summarizes the job results
+- `data.tar.gz` contains raw test data as Feather files encoding a DataFrame. To untar this file, run
+`tar -xzvf data.tar.gz`.
+- `logs` is a directory containing the test logs for the job.
+
 ## Acknowledgements
 
 The development of the Nanosoldier benchmarking platform was supported in part by the US

--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ The `vs` keyword argument takes a reference string which can points to a Julia c
 
 - `":branch"`: the head commit of the branch named `branch` in the current repository (`JuliaLang/julia`)
 - `"@sha"`: the commit specified by `sha` in the current repository (`JuliaLang/julia`)
+- `"#tag"`: the commit pointed to by the tag named `tag` in the current repository (`JuliaLang/julia`)
 - `"owner/repo:branch"`: the head commit of the branch named `branch` in the repository `owner/repo`
 - `"owner/repo@sha"`: the commit specified by `sha` in the repository `owner/repo`
+- `"owner/repo#tag"`: the commit pointed to by the tag named `tag` in the repository `owner/repo`
 
 #### Benchmark Results
 

--- a/bin/run_base_pkgeval.jl
+++ b/bin/run_base_pkgeval.jl
@@ -4,11 +4,10 @@ import Nanosoldier, GitHub
 nodes = Dict(Any => addprocs(1; exeflags="--project"))
 @everywhere import Nanosoldier
 
-cpus = [i for i in 1:Sys.CPU_THREADS]
 auth = GitHub.authenticate(ENV["GITHUB_AUTH"])
 secret = ENV["GITHUB_SECRET"]
 
-config = Nanosoldier.Config(ENV["USER"], nodes, cpus, auth, secret;
+config = Nanosoldier.Config(ENV["USER"], nodes, auth, secret;
                             workdir = joinpath(dirname(@__DIR__), "workdir"),
                             trackrepo = "maleadt/julia",
                             reportrepo = "maleadt/BasePkgEvalReports",

--- a/bin/run_base_pkgeval.jl
+++ b/bin/run_base_pkgeval.jl
@@ -9,7 +9,7 @@ secret = ENV["GITHUB_SECRET"]
 
 config = Nanosoldier.Config(ENV["USER"], nodes, auth, secret;
                             workdir = joinpath(dirname(@__DIR__), "workdir"),
-                            trackrepo = "maleadt/julia",
+                            trackrepo = "JuliaLang/julia",
                             reportrepo = "maleadt/BasePkgEvalReports",
                             trigger = r"\@nanosoldier\s*`runtests\(.*?\)`",
                             admin = "maleadt")

--- a/bin/run_base_pkgeval.jl
+++ b/bin/run_base_pkgeval.jl
@@ -1,8 +1,8 @@
 using Distributed
-
-nodes = addprocs(1; exeflags="--project")
-
 import Nanosoldier, GitHub
+
+nodes = Dict(Any => addprocs(1; exeflags="--project"))
+@everywhere import Nanosoldier
 
 cpus = [i for i in 1:Sys.CPU_THREADS]
 auth = GitHub.authenticate(ENV["GITHUB_AUTH"])
@@ -18,5 +18,4 @@ config = Nanosoldier.Config(ENV["USER"], nodes, cpus, auth, secret;
 server = Nanosoldier.Server(config)
 
 using Sockets
-
 run(server, IPv4(0,0,0,0), 8888)

--- a/bin/run_base_pkgeval.jl
+++ b/bin/run_base_pkgeval.jl
@@ -1,0 +1,22 @@
+using Distributed
+
+nodes = addprocs(1; exeflags="--project")
+
+import Nanosoldier, GitHub
+
+cpus = [i for i in 1:Sys.CPU_THREADS]
+auth = GitHub.authenticate(ENV["GITHUB_AUTH"])
+secret = ENV["GITHUB_SECRET"]
+
+config = Nanosoldier.Config(ENV["USER"], nodes, cpus, auth, secret;
+                            workdir = joinpath(dirname(@__DIR__), "workdir"),
+                            trackrepo = "maleadt/julia",
+                            reportrepo = "maleadt/BasePkgEvalReports",
+                            trigger = r"\@nanosoldier\s*`runtests\(.*?\)`",
+                            admin = "maleadt")
+
+server = Nanosoldier.Server(config)
+
+using Sockets
+
+run(server, IPv4(0,0,0,0), 8888)

--- a/bin/setup_base_ci.jl
+++ b/bin/setup_base_ci.jl
@@ -1,8 +1,8 @@
 using Distributed
-
-nodes = addprocs(["nanosoldier7", "nanosoldier8"])
-
 import Nanosoldier, GitHub
+
+nodes = Dict(Any => addprocs(["nanosoldier7", "nanosoldier8"]))
+@everywhere import Nanosoldier
 
 cpus = [1,2,3]
 auth = GitHub.authenticate(ENV["GITHUB_AUTH"])

--- a/bin/setup_base_ci.jl
+++ b/bin/setup_base_ci.jl
@@ -4,11 +4,10 @@ import Nanosoldier, GitHub
 nodes = Dict(Any => addprocs(["nanosoldier7", "nanosoldier8"]))
 @everywhere import Nanosoldier
 
-cpus = [1,2,3]
 auth = GitHub.authenticate(ENV["GITHUB_AUTH"])
 secret = ENV["GITHUB_SECRET"]
 
-config = Nanosoldier.Config(ENV["USER"], nodes, cpus, auth, secret;
+config = Nanosoldier.Config(ENV["USER"], nodes, auth, secret;
                             workdir = joinpath(homedir(), "workdir"),
                             trackrepo = "JuliaLang/julia",
                             reportrepo = "JuliaCI/BaseBenchmarkReports",

--- a/bin/setup_test_ci.jl
+++ b/bin/setup_test_ci.jl
@@ -1,8 +1,8 @@
 using Distributed
-
-nodes = addprocs(["nanosoldier6"])
-
 import Nanosoldier, GitHub
+
+nodes = Dict(Any => addprocs(["nanosoldier6"]))
+@everywhere import Nanosoldier
 
 cpus = [1,2,3]
 auth = GitHub.authenticate(ENV["GITHUB_AUTH"])

--- a/bin/setup_test_ci.jl
+++ b/bin/setup_test_ci.jl
@@ -4,11 +4,10 @@ import Nanosoldier, GitHub
 nodes = Dict(Any => addprocs(["nanosoldier6"]))
 @everywhere import Nanosoldier
 
-cpus = [1,2,3]
 auth = GitHub.authenticate(ENV["GITHUB_AUTH"])
 secret = ENV["GITHUB_SECRET"]
 
-config = Nanosoldier.Config(ENV["USER"], nodes, cpus, auth, secret;
+config = Nanosoldier.Config(ENV["USER"], nodes, auth, secret;
                             workdir = joinpath(homedir(), "test_workdir"),
                             trackrepo = "ararslan/julia",
                             reportrepo = "ararslan/BaseBenchmarkReports",

--- a/bin/submit_daily_job.jl
+++ b/bin/submit_daily_job.jl
@@ -3,10 +3,17 @@ import GitHub
 auth = GitHub.authenticate(ENV["GITHUB_AUTH"])
 repo = "JuliaLang/julia"
 sha = GitHub.branch(repo, "master").commit.sha
+
 message = """
           Executing the daily benchmark build, I will reply here when finished:
 
           @nanosoldier `runbenchmarks(ALL, isdaily = true)`
           """
+GitHub.create_comment(repo, sha, :commit, auth=auth, params=Dict("body" => message))
 
+message = """
+          Executing the daily package evaluation, I will reply here when finished:
+
+          @nanosoldier `runtests(ALL, isdaily = true)`
+          """
 GitHub.create_comment(repo, sha, :commit, auth=auth, params=Dict("body" => message))

--- a/src/Nanosoldier.jl
+++ b/src/Nanosoldier.jl
@@ -3,7 +3,6 @@ module Nanosoldier
 using Dates, Distributed, Printf, InteractiveUtils
 import GitHub, BenchmarkTools, JSON, HTTP
 
-const TRIGGER = r"\@nanosoldier\s*`.*?`"
 const SHA_SEPARATOR = '@'
 const BRANCH_SEPARATOR = ':'
 

--- a/src/Nanosoldier.jl
+++ b/src/Nanosoldier.jl
@@ -14,7 +14,15 @@ const BRANCH_SEPARATOR = ':'
 snip(str, len) = str[1:min(len, end)]
 snipsha(sha) = snip(sha, 7)
 
-gitclone!(repo, path) = run(`git clone git@github.com:$(repo).git $(path)`)
+function gitclone!(repo, path, auth=nothing)
+    if isa(auth, GitHub.OAuth2)
+        run(`git clone https://$(auth.token):x-oauth-basic@github.com/$(repo).git $(path)`)
+    elseif isa(auth, GitHub.UsernamePassAuth)
+        run(`git clone https://$(auth.username):$(auth.password)@github.com/$(repo).git $(path)`)
+    else
+        run(`git clone git@github.com:$(repo).git $(path)`)
+    end
+end
 
 gitreset!() = (run(`git fetch --all`); run(`git reset --hard origin/master`))
 gitreset!(path) = cd(gitreset!, path)

--- a/src/Nanosoldier.jl
+++ b/src/Nanosoldier.jl
@@ -5,6 +5,7 @@ import GitHub, BenchmarkTools, JSON, HTTP
 
 const SHA_SEPARATOR = '@'
 const BRANCH_SEPARATOR = ':'
+const TAG_SEPARATOR = '#'
 
 #####################
 # utility functions #

--- a/src/build.jl
+++ b/src/build.jl
@@ -50,7 +50,8 @@ function build_julia!(config::Config, build::BuildRef, logpath, prnumber::Union{
     errfile = joinpath(logpath, string(logname, ".err"))
 
     # run the build
-    run(pipeline(`make -j$(length(config.cpus)) USECCACHE=1 USE_BINARYBUILDER_LLVM=0`,
+    cpus = mycpus(config)
+    run(pipeline(`make -j$(length(cpus)) USECCACHE=1 USE_BINARYBUILDER_LLVM=0`,
                  stdout=outfile, stderr=errfile))
     cd(workdir(config))
     return builddir

--- a/src/config.jl
+++ b/src/config.jl
@@ -37,7 +37,7 @@ function persistdir!(config::Config)
     if isdir(reportdir(config))
         gitreset!(reportdir(config))
     else
-        gitclone!(reportrepo(config), reportdir(config))
+        gitclone!(reportrepo(config), reportdir(config), config.auth)
     end
 end
 

--- a/src/config.jl
+++ b/src/config.jl
@@ -6,6 +6,7 @@ struct Config
     secret::String             # the GitHub secret used to validate webhooks
     trackrepo::String          # the main Julia repo tracked by the server
     reportrepo::String         # the repo to which result reports are posted
+    trigger::Regex             # a regular expression to match comments against
     workdir::String            # the server's work directory
     testmode::Bool             # if true, jobs will run as test jobs
 
@@ -13,11 +14,12 @@ struct Config
                     workdir = pwd(),
                     trackrepo = "JuliaLang/julia",
                     reportrepo = "JuliaCI/BaseBenchmarkReports",
+                    trigger =  r"\@nanosoldier\s*`runbenchmarks\(.*?\)`",
                     testmode = false)
         isempty(nodes) && throw(ArgumentError("need at least one node to work on"))
         isempty(cpus) && throw(ArgumentError("need at least one cpu per node to work on"))
         return new(user, nodes, cpus, auth, secret, trackrepo,
-                   reportrepo, workdir, testmode)
+                   reportrepo, trigger, workdir, testmode)
     end
 end
 

--- a/src/config.jl
+++ b/src/config.jl
@@ -8,6 +8,7 @@ struct Config
     reportrepo::String         # the repo to which result reports are posted
     trigger::Regex             # a regular expression to match comments against
     workdir::String            # the server's work directory
+    admin::String              # GitHub handle of the server administrator
     testmode::Bool             # if true, jobs will run as test jobs
 
     function Config(user, nodes, cpus, auth, secret;
@@ -15,11 +16,12 @@ struct Config
                     trackrepo = "JuliaLang/julia",
                     reportrepo = "JuliaCI/BaseBenchmarkReports",
                     trigger =  r"\@nanosoldier\s*`runbenchmarks\(.*?\)`",
+                    admin = "ararslan",
                     testmode = false)
         isempty(nodes) && throw(ArgumentError("need at least one node to work on"))
         isempty(cpus) && throw(ArgumentError("need at least one cpu per node to work on"))
         return new(user, nodes, cpus, auth, secret, trackrepo,
-                   reportrepo, trigger, workdir, testmode)
+                   reportrepo, trigger, workdir, admin, testmode)
     end
 end
 

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,15 +1,15 @@
 struct Config
-    user::String               # the OS username of the user running the server
-    nodes::Vector{Int}         # the pids for the nodes on the cluster
-    cpus::Vector{Int}          # the indices of the cpus per node
-    auth::GitHub.Authorization # the GitHub authorization used to post statuses/reports
-    secret::String             # the GitHub secret used to validate webhooks
-    trackrepo::String          # the main Julia repo tracked by the server
-    reportrepo::String         # the repo to which result reports are posted
-    trigger::Regex             # a regular expression to match comments against
-    workdir::String            # the server's work directory
-    admin::String              # GitHub handle of the server administrator
-    testmode::Bool             # if true, jobs will run as test jobs
+    user::String                    # the OS username of the user running the server
+    nodes::Dict{Type,Vector{Int}}   # the pids for the nodes on the cluster
+    cpus::Vector{Int}               # the indices of the cpus per node
+    auth::GitHub.Authorization      # the GitHub authorization used to post statuses/reports
+    secret::String                  # the GitHub secret used to validate webhooks
+    trackrepo::String               # the main Julia repo tracked by the server
+    reportrepo::String              # the repo to which result reports are posted
+    trigger::Regex                  # a regular expression to match comments against
+    workdir::String                 # the server's work directory
+    admin::String                   # GitHub handle of the server administrator
+    testmode::Bool                  # if true, jobs will run as test jobs
 
     function Config(user, nodes, cpus, auth, secret;
                     workdir = pwd(),

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -438,7 +438,7 @@ function report(job::BenchmarkJob, results)
         reply_status(job, "error", "no benchmarks were executed")
         reply_comment(job, "[Your benchmark job]($(submission(job).url)) has completed, " *
                       "but no benchmarks were actually executed. Perhaps your tag predicate " *
-                      "contains misspelled tags? cc @ararslan")
+                      "contains misspelled tags? cc @$(cfg.admin)")
     else
         #  prepare report + data and push it to report repo
         target_url = ""
@@ -481,10 +481,10 @@ function report(job::BenchmarkJob, results)
             reply_status(job, state, status, target_url)
             if isempty(target_url)
                 comment = "[Your benchmark job]($(submission(job).url)) has completed, but " *
-                          "something went wrong when trying to upload the result data. cc @ararslan"
+                          "something went wrong when trying to upload the result data. cc @$(cfg.admin)"
             else
                 comment = "[Your benchmark job]($(submission(job).url)) has completed - " *
-                          "$(status). A full report can be found [here]($(target_url)). cc @ararslan"
+                          "$(status). A full report can be found [here]($(target_url)). cc @$(cfg.admin)"
             end
             reply_comment(job, comment)
         end

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -60,6 +60,10 @@ function BenchmarkJob(submission::JobSubmission)
             reporef, againstbranch = split(againststr, BRANCH_SEPARATOR)
             againstrepo = isempty(reporef) ? submission.config.trackrepo : reporef
             againstbuild = branchref(submission.config, againstrepo, againstbranch)
+        elseif in(TAG_SEPARATOR, againststr)
+            reporef, againsttag = split(againststr, TAG_SEPARATOR)
+            againstrepo = isempty(reporef) ? submission.config.trackrepo : reporef
+            againstbuild = tagref(submission.config, againstrepo, againsttag)
         else
             error("invalid argument to `vs` keyword")
         end

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -109,13 +109,6 @@ submission(job::BenchmarkJob) = job.submission
 # Utilities #
 #############
 
-function branchref(config::Config, reponame::AbstractString, branchname::AbstractString)
-    shastr = GitHub.branch(reponame, branchname; auth=config.auth).commit.sha
-    return BuildRef(reponame, shastr)
-end
-
-datedirname(date::Dates.Date) = string("daily_", Dates.format(date, dateformat"yyyy_mm_dd"))
-
 function jobdirname(job::BenchmarkJob)
     if job.isdaily
         return datedirname(job.date)

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -465,7 +465,7 @@ function report(job::BenchmarkJob, results)
         if haskey(results, "error")
             err = results["error"]
             err.url = target_url
-            rethrow(err)
+            throw(err)
         else
             # determine the job's final status
             if job.against !== nothing || haskey(results, "previous_date")

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -114,17 +114,18 @@ submission(job::BenchmarkJob) = job.submission
 #############
 
 function jobdirname(job::BenchmarkJob)
-    if job.isdaily
-        return datedirname(job.date)
+    tag = if job.isdaily
+        datedirname(job.date)
     else
         primarysha = snipsha(submission(job).build.sha)
         if job.against === nothing
-            return primarysha
+            primarysha
         else
             againstsha = snipsha(job.against.sha)
-            return string(primarysha, "_vs_", againstsha)
+            string(primarysha, "_vs_", againstsha)
         end
     end
+    return "benchmark-$tag"
 end
 
 reportdir(job::BenchmarkJob) = joinpath(reportdir(submission(job).config), jobdirname(job))
@@ -133,7 +134,7 @@ tmplogdir(job::BenchmarkJob) = joinpath(tmpdir(job), "logs")
 tmpdatadir(job::BenchmarkJob) = joinpath(tmpdir(job), "data")
 
 function retrieve_daily_data!(results, key, cfg, date)
-    dailydir = joinpath(reportdir(cfg), datedirname(date))
+    dailydir = joinpath(reportdir(cfg), "benchmark-" * datedirname(date))
     found_previous_date = false
     if isdir(dailydir)
         cd(dailydir) do

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -397,8 +397,9 @@ function execute_benchmarks!(job::BenchmarkJob, whichbuild::Symbol)
     catch
     end
     # shield our CPUs
-    run(`sudo cset shield -c $(join(cfg.cpus, ",")) -k on`)
-    run(`sudo cset set -c $(first(cfg.cpus)) -s /user/child --cpu_exclusive`)
+    cpus = mycpus(cfg)
+    run(`sudo cset shield -c $(join(cpus, ",")) -k on`)
+    run(`sudo cset set -c $(first(cpus)) -s /user/child --cpu_exclusive`)
 
     # execute our script as the server user on the shielded CPU
     nodelog(cfg, node, "...executing benchmarks...")

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -170,7 +170,7 @@ function execute_tests!(job::PkgEvalJob, build::BuildRef, whichbuild::Symbol)
     if whichbuild == :primary && submission(job).fromkind == :pr
         # if we're dealing with a PR, try the merge commit
         pr = submission(job).prnumber
-        if prnumber !== nothing
+        if pr !== nothing
             try
                 julia = NewPkgEval.obtain_julia_build("pull/$pr/merge", build.repo)
             catch err

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -501,7 +501,7 @@ function printreport(io::IO, job::PkgEvalJob, results)
                 if test.source == "both"
                     against_log = "logs/$(test.name_1)/$(test.julia_1).log"
                     if hasprevdate
-                        against_log = "../$(datedirname(results["previous_date"]))/$against_log"
+                        against_log = "../pkgeval-$(datedirname(results["previous_date"]))/$against_log"
                     end
                     print(io, " vs. [$(test.name_1)$(verstr(test.version_1))]($against_log)")
 

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -61,6 +61,10 @@ function PkgEvalJob(submission::JobSubmission)
             reporef, againstbranch = split(againststr, BRANCH_SEPARATOR)
             againstrepo = isempty(reporef) ? submission.config.trackrepo : reporef
             againstbuild = branchref(submission.config, againstrepo, againstbranch)
+        elseif in(TAG_SEPARATOR, againststr)
+            reporef, againsttag = split(againststr, TAG_SEPARATOR)
+            againstrepo = isempty(reporef) ? submission.config.trackrepo : reporef
+            againstbuild = tagref(submission.config, againstrepo, againsttag)
         else
             error("invalid argument to `vs` keyword")
         end

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -109,17 +109,18 @@ submission(job::PkgEvalJob) = job.submission
 #############
 
 function jobdirname(job::PkgEvalJob)
-    if job.isdaily
-        return datedirname(job.date)
+    tag = if job.isdaily
+        datedirname(job.date)
     else
         primarysha = snipsha(submission(job).build.sha)
         if job.against === nothing
-            return primarysha
+            primarysha
         else
             againstsha = snipsha(job.against.sha)
-            return string(primarysha, "_vs_", againstsha)
+            string(primarysha, "_vs_", againstsha)
         end
     end
+    return "pkgeval-$tag"
 end
 
 reportdir(job::PkgEvalJob) = joinpath(reportdir(submission(job).config), jobdirname(job))
@@ -128,7 +129,7 @@ tmplogdir(job::PkgEvalJob) = joinpath(tmpdir(job), "logs")
 tmpdatadir(job::PkgEvalJob) = joinpath(tmpdir(job), "data")
 
 function retrieve_daily_tests!(results, key, cfg, date)
-    dailydir = joinpath(reportdir(cfg), datedirname(date))
+    dailydir = joinpath(reportdir(cfg), "pkgeval-" * datedirname(date))
     found_previous_date = false
     if isdir(dailydir)
         cd(dailydir) do

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -460,14 +460,16 @@ function printreport(io::IO, job::PkgEvalJob, results)
     results["has_issues"] = false
 
     # report test results in groups based on the test status
-    for (status, verb) in (:fail=>"failed tests", :ok=>"passed tests",
-                           :kill=>"were killed", :skip=>"were skipped")
+    for (status, (verb, emoji)) in (:fail   => ("failed tests", ":heavy_multiplication_x:"),
+                                    :ok     => ("passed tests", ":heavy_check_mark:"),
+                                    :kill   => ("were killed",  ":heavy_exclamation_mark:"),
+                                    :skip   => ("were skipped", ":heavy_minus_sign:"))
         # NOTE: no `groupby(package_results, :status)` because we can't impose ordering
         group = package_results[package_results[!, :status] .== status, :]
         sort!(group, :name)
 
         if !isempty(group)
-            println(io, "## Packages that", iscomparisonjob ? " now" : "", " $verb\n")
+            println(io, "## $emoji Packages that", iscomparisonjob ? " now" : "", " $verb\n")
 
             function reportrow(test)
                 verstr(version) = ismissing(version) ? "" : " v$(version)"

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -1,1 +1,593 @@
-# TODO
+using NewPkgEval
+using DataFrames
+using Feather
+using JSON
+using Base: UUID
+
+
+################################
+# Package Selection Validation #
+################################
+
+# The package selection is valid if it is simply a single package, "ALL", or an
+# array expression that lists several packages. This validation is
+# only to prevent server-side evaluation of arbitrary code. No check is
+# performed to ensure that the tag predicate is grammatically correct.
+
+function is_valid_pkgsel(pkgsel::AbstractString)
+    parsed = Meta.parse(pkgsel)
+    if isa(parsed, Expr)
+        return is_valid_pkgsel(parsed)
+    elseif parsed == :ALL
+        return true
+    else
+        return isa(parsed, AbstractString)
+    end
+end
+
+function is_valid_pkgsel(pkgsel::Expr)
+    if pkgsel.head != :vect
+        return false
+    else
+        for item in pkgsel.args
+            if !isa(item, AbstractString)
+                return false
+            end
+        end
+    end
+    return true
+end
+
+##############
+# PkgEvalJob #
+##############
+
+mutable struct PkgEvalJob <: AbstractJob
+    submission::JobSubmission        # the original submission
+    pkgsel::String                   # selection of packages
+    against::Union{BuildRef,Nothing} # the comparison build (if available)
+    date::Dates.Date                 # the date of the submitted job
+    isdaily::Bool                    # is the job a daily job?
+end
+
+function PkgEvalJob(submission::JobSubmission)
+    if haskey(submission.kwargs, :vs)
+        againststr = Meta.parse(submission.kwargs[:vs])
+        if in(SHA_SEPARATOR, againststr) # e.g. againststr == ararslan/julia@e83b7559df94b3050603847dbd6f3674058027e6
+            reporef, againstsha = split(againststr, SHA_SEPARATOR)
+            againstrepo = isempty(reporef) ? submission.config.trackrepo : reporef
+            againstbuild = BuildRef(againstrepo, againstsha)
+        elseif in(BRANCH_SEPARATOR, againststr)
+            reporef, againstbranch = split(againststr, BRANCH_SEPARATOR)
+            againstrepo = isempty(reporef) ? submission.config.trackrepo : reporef
+            againstbuild = branchref(submission.config, againstrepo, againstbranch)
+        else
+            error("invalid argument to `vs` keyword")
+        end
+        against = againstbuild
+    else
+        against = nothing
+    end
+
+    if haskey(submission.kwargs, :isdaily)
+        isdaily = submission.kwargs[:isdaily] == "true"
+    else
+        isdaily = false
+    end
+
+    return PkgEvalJob(submission, first(submission.args), against,
+                      Dates.today(), isdaily)
+end
+
+function Base.summary(job::PkgEvalJob)
+    result = "PkgEvalJob $(summary(submission(job).build))"
+    if job.isdaily
+        result *= " [daily]"
+    elseif job.against !== nothing
+        result *= " vs. $(summary(job.against))"
+    end
+    return result
+end
+
+function isvalid(submission::JobSubmission, ::Type{PkgEvalJob})
+    allowed_kwargs = (:vs, :isdaily)
+    args, kwargs = submission.args, submission.kwargs
+    has_valid_args = length(args) == 1 && is_valid_pkgsel(first(args))
+    has_valid_kwargs = (all(in(allowed_kwargs), keys(kwargs)) &&
+                        (length(kwargs) <= length(allowed_kwargs)))
+    return (submission.func == "runtests") && has_valid_args && has_valid_kwargs
+end
+
+submission(job::PkgEvalJob) = job.submission
+
+#############
+# Utilities #
+#############
+
+function jobdirname(job::PkgEvalJob)
+    if job.isdaily
+        return datedirname(job.date)
+    else
+        primarysha = snipsha(submission(job).build.sha)
+        if job.against === nothing
+            return primarysha
+        else
+            againstsha = snipsha(job.against.sha)
+            return string(primarysha, "_vs_", againstsha)
+        end
+    end
+end
+
+reportdir(job::PkgEvalJob) = joinpath(reportdir(submission(job).config), jobdirname(job))
+tmpdir(job::PkgEvalJob) = joinpath(workdir(submission(job).config), "tmpresults")
+tmplogdir(job::PkgEvalJob) = joinpath(tmpdir(job), "logs")
+tmpdatadir(job::PkgEvalJob) = joinpath(tmpdir(job), "data")
+
+function retrieve_daily_tests!(results, key, cfg, date)
+    dailydir = joinpath(reportdir(cfg), datedirname(date))
+    found_previous_date = false
+    if isdir(dailydir)
+        cd(dailydir) do
+            datapath = joinpath(dailydir, "data")
+            try
+                run(`tar -xzf data.tar.gz`)
+                results[key] = Feather.read(joinpath(datapath, "primary.feather"))
+                found_previous_date = true
+
+                # undo stringification
+                for col in (:julia, :version, :status, :reason, :uuid)
+                    results[key][!, col] = map(str->eval(Meta.parse(str)), results[key][!, col])
+                end
+            catch err
+                nodelog(cfg, myid(),
+                        "encountered error when retrieving daily data: " * sprint(showerror, err),
+                        error=(err, stacktrace(catch_backtrace())))
+            finally
+                isdir(datapath) && rm(datapath, recursive=true)
+            end
+        end
+    end
+    return found_previous_date
+end
+
+########################
+# PkgEvalJob Execution #
+########################
+
+function execute_tests!(job::PkgEvalJob, build::BuildRef, whichbuild::Symbol)
+    # determine Julia version to use
+    julia = NewPkgEval.obtain_julia_build(build.sha, build.repo)
+    NewPkgEval.prepare_julia(julia)
+
+    # get some version info
+    try
+        out = Pipe()
+        NewPkgEval.run_sandboxed_julia(julia, ```-e '
+                VERSION >= v"0.7.0-DEV.3630" && using InteractiveUtils
+                VERSION >= v"0.7.0-DEV.467" ? versioninfo(verbose=true) : versioninfo(true)
+                '
+            ```; stdout=out, stderr=out, stdin=devnull, interactive=false)
+        close(out.in)
+        build.vinfo = first(split(read(out, String), "Environment"))
+    catch err
+        build.vinfo = string("retrieving versioninfo() failed: ", sprint(showerror, err))
+    end
+
+    # determine packages to test
+    pkgsel = Meta.parse(job.pkgsel)
+    pkg_names = if pkgsel == :ALL
+        String[]
+    else
+        eval(pkgsel)    # should be safe, it's a :vec of Strings
+    end
+    pkgs = NewPkgEval.read_pkgs(pkg_names)
+
+    # run tests
+    results = withenv("CI" => true) do
+        NewPkgEval.run([julia], pkgs; ninstances=length(submission(job).config.cpus))
+    end
+
+    # write logs
+    cd(tmplogdir(job)) do
+        for test in eachrow(results)
+            isdir(test.name) || mkdir(test.name)
+            open(joinpath(test.name, "$(test.julia).log"), "w") do io
+                if !ismissing(test.log)
+                    write(io, test.log)
+                end
+            end
+        end
+    end
+
+    # write data
+    cd(tmpdatadir(job)) do
+        let results = copy(results)
+            # Feather can't handle non-primitive types, so stringify them
+            for col in (:julia, :version, :status, :reason, :uuid)
+                results[!, col] = map(repr, results[!, col])
+            end
+            Feather.write("$(whichbuild).feather", results)
+        end
+    end
+
+    return results
+end
+
+function Base.run(job::PkgEvalJob)
+    node = myid()
+    cfg = submission(job).config
+
+    # make temporary directory for job results
+    # Why not create the job's actual report directory now instead? The answer is that
+    # the commit SHA that currently describes the job might change if we find out that
+    # we should use a merge commit instead. To avoid confusion, we dump all the results
+    # to this temporary directory first, then move the data to the correct location
+    # in the reporting phase.
+    nodelog(cfg, node, "creating temporary directory for benchmark results")
+    if isdir(tmpdir(job))
+        nodelog(cfg, node, "...removing old temporary directory...")
+        rm(tmpdir(job), recursive=true)
+    end
+    nodelog(cfg, node, "...creating $(tmpdir(job))...")
+    mkdir(tmpdir(job))
+    nodelog(cfg, node, "...creating $(tmplogdir(job))...")
+    mkdir(tmplogdir(job))
+    nodelog(cfg, node, "...creating $(tmpdatadir(job))...")
+    mkdir(tmpdatadir(job))
+
+    # prepare NewPkgEval
+    NewPkgEval.prepare_registry("General"; update=true)
+    NewPkgEval.prepare_runner()
+
+    # instantiate the dictionary that will hold all of the info needed by `report`
+    results = Dict{Any,Any}()
+
+    # run primary job
+    try
+        nodelog(cfg, node, "running primary build for $(summary(job))")
+        results["primary"] = execute_tests!(job, submission(job).build, :primary)
+        nodelog(cfg, node, "running primary build for $(summary(job))")
+    catch err
+        results["error"] = NanosoldierError("failed to run tests against primary commit", err)
+    end
+
+    # as long as our primary job didn't error, run the comparison job (or if it's a daily job, gather results to compare against)
+    if !haskey(results, "error")
+        if job.isdaily # get results from previous day (if it exists, check the past 30 days)
+            try
+                nodelog(cfg, node, "retrieving results from previous daily build")
+                found_previous_date = false
+                i = 1
+                while !found_previous_date && i < 31
+                    check_date = job.date - Dates.Day(i)
+                    found_previous_date = retrieve_daily_tests!(results, "against", cfg, check_date)
+                    found_previous_date && (results["previous_date"] = check_date)
+                    i += 1
+                end
+                found_previous_date || nodelog(cfg, node, "didn't find previous daily build data in the past 31 days")
+            catch err
+                rethrow(NanosoldierError("encountered error when retrieving old daily build data", err))
+            end
+        elseif job.against !== nothing # run comparison build
+            try
+                nodelog(cfg, node, "running comparison build for $(summary(job))")
+                results["against"] = execute_tests!(job, job.against, :against)
+                nodelog(cfg, node, "finished comparison build for $(summary(job))")
+            catch err
+                rethrow()
+                results["error"] = NanosoldierError("failed to run tests against comparison commit", err)
+            end
+        end
+    end
+
+    NewPkgEval.purge()
+
+    # report results
+    nodelog(cfg, node, "reporting results for $(summary(job))")
+    report(job, results)
+    nodelog(cfg, node, "completed $(summary(job))")
+
+    return
+end
+
+########################
+# PkgEvalJob Reporting #
+########################
+
+# report job results back to GitHub
+function report(job::PkgEvalJob, results)
+    node = myid()
+    cfg = submission(job).config
+    if haskey(results, "primary") && isempty(results["primary"])
+        reply_status(job, "error", "no tests were executed")
+        reply_comment(job, "[Your test job]($(submission(job).url)) has completed, " *
+                      "but no tests were actually executed. Perhaps your package selection " *
+                      "contains misspelled names? cc @maleadt")
+    else
+        #  prepare report + data and push it to report repo
+        target_url = ""
+        try
+            nodelog(cfg, node, "...generating report...")
+            reportname = "report.md"
+            open(joinpath(tmpdir(job), reportname), "w") do file
+                printreport(file, job, results)
+            end
+            if job.isdaily
+                nodelog(cfg, node, "...generating database...")
+                dbname = "db.json"
+                open(joinpath(tmpdir(job), dbname), "w") do file
+                    printdb(file, job, results)
+                end
+            end
+            nodelog(cfg, node, "...tarring data...")
+            cd(tmpdir(job)) do
+                run(`tar -zcf data.tar.gz data`)
+                rm(tmpdatadir(job), recursive=true)
+            end
+            nodelog(cfg, node, "...moving $(tmpdir(job)) to $(reportdir(job))...")
+            mv(tmpdir(job), reportdir(job); force=true)
+            nodelog(cfg, node, "...pushing $(reportdir(job)) to GitHub...")
+            target_url = upload_report_repo!(job, joinpath(jobdirname(job), reportname),
+                                             "upload report for $(summary(job))")
+        catch err
+            rethrow(NanosoldierError("error when preparing/pushing to report repo", err))
+        end
+
+        if haskey(results, "error")
+            err = results["error"]
+            err.url = target_url
+            throw(err)
+        else
+            # determine the job's final status
+            state = results["has_issues"] ? "failure" : "success"
+            if job.against !== nothing || haskey(results, "previous_date")
+                status = results["has_issues"] ? "possible new issues were detected" :
+                                                 "no new issues were detected"
+            else
+                status = results["has_issues"] ? "possible issues were detected" :
+                                                 "no issues were detected"
+            end
+            # reply with the job's final status
+            reply_status(job, state, status, target_url)
+            if isempty(target_url)
+                comment = "[Your test job]($(submission(job).url)) has completed, but " *
+                          "something went wrong when trying to upload the result data. cc @maleadt"
+            else
+                comment = "[Your test job]($(submission(job).url)) has completed - " *
+                          "$(status). A full report can be found [here]($(target_url)). cc @maleadt"
+            end
+            reply_comment(job, comment)
+        end
+    end
+end
+
+# Markdown Report Generation #
+#----------------------------#
+
+function printreport(io::IO, job::PkgEvalJob, results)
+    build = submission(job).build
+    buildname = string(build.repo, SHA_SEPARATOR, build.sha)
+    buildlink = "https://github.com/$(build.repo)/commit/$(build.sha)"
+    joblink = "[$(buildname)]($(buildlink))"
+    hasagainstbuild = job.against !== nothing
+    hasprevdate = haskey(results, "previous_date")
+    iscomparisonjob = hasagainstbuild || hasprevdate
+
+    if hasagainstbuild
+        againstbuild = job.against
+        againstname = string(againstbuild.repo, SHA_SEPARATOR, againstbuild.sha)
+        againstlink = "https://github.com/$(againstbuild.repo)/commit/$(againstbuild.sha)"
+        joblink = "$(joblink) vs [$(againstname)]($(againstlink))"
+    end
+
+    # print report preface + job properties #
+    #---------------------------------------#
+
+    println(io, """
+                # Package Evaluation Report
+
+                ## Job Properties
+
+                *Commit(s):* $(joblink)
+
+                *Triggered By:* [link]($(submission(job).url))
+
+                *Package Selection:* `$(job.pkgsel)`
+                """)
+
+    if job.isdaily
+        if hasprevdate
+            dailystr = string(job.date, " vs ", results["previous_date"])
+        else
+            dailystr = string(job.date)
+        end
+        println(io, """
+                    *Daily Job:* $(dailystr)
+                    """)
+    end
+
+    # if errors are found, end the report now #
+    #-----------------------------------------#
+
+    if haskey(results, "error")
+        println(io, """
+                    ## Error
+
+                    The build could not finish due to an error:
+
+                    ```
+                    $(results["error"])
+                    ```
+
+                    Check the logs folder in this directory for more detailed output.
+                    """)
+        return nothing
+    end
+
+    # print result list #
+    #-------------------#
+
+    if iscomparisonjob
+        package_results = join(results["primary"], results["against"],
+                               on=:uuid, kind=:left, makeunique=true, indicator=:source)
+    else
+        package_results = results["primary"]
+        package_results[!, :source] .= "left_only" # fake a left join
+    end
+
+    results["has_issues"] = false
+
+    # report test results in groups based on the test status
+    for (status, verb) in (:fail=>"failed tests", :ok=>"passed tests",
+                           :kill=>"were killed", :skip=>"were skipped")
+        # NOTE: no `groupby(package_results, :status)` because we can't impose ordering
+        group = package_results[package_results[!, :status] .== status, :]
+        sort!(group, :name)
+
+        if !isempty(group)
+            println(io, "## Packages that", iscomparisonjob ? " now" : "", " $verb\n")
+
+            function reportrow(test)
+                verstr(version) = ismissing(version) ? "" : " v$(version)"
+
+                primary_log = "logs/$(test.name)/$(test.julia).log"
+                print(io, "- [$(test.name)$(verstr(test.version))]($primary_log)")
+
+                if !ismissing(test.reason)
+                    print(io, " ($(NewPkgEval.reasons[test.reason]))")
+                end
+
+                # "against" entries are suffixed with `_1` because of the join
+                if test.source == "both"
+                    against_log = "logs/$(test.name_1)/$(test.julia_1).log"
+                    if hasprevdate
+                        against_log = "../$(datedirname(results["previous_date"]))/$against_log"
+                    end
+                    print(io, " vs. [$(test.name_1)$(verstr(test.version_1))]($against_log)")
+
+                    print(io, " ($(NewPkgEval.statusses[test.status_1])")
+                    if !ismissing(test.reason_1)
+                        print(io, ", $(NewPkgEval.reasons[test.reason_1])")
+                    end
+                    print(io, ")")
+                end
+
+                println(io)
+            end
+
+            if iscomparisonjob
+                # first report on tests that changed status
+                let changed_tests = filter(test->test.source == "both" &&
+                                                 test.status != test.status_1, group)
+                    println(io, "$(nrow(changed_tests)) packages $verb only on the current version.")
+                    println(io)
+                    foreach(reportrow, eachrow(changed_tests))
+
+                    results["has_issues"] |= status in (:fail, :kill) && !isempty(changed_tests)
+                end
+
+                # now report the other ones
+                let unchanged_tests = filter(test->test.source == "left_only" ||
+                                                   test.status == test.status_1, group)
+                    println(io, """
+                        <details><summary>$(nrow(unchanged_tests)) packages $verb on the previous version too.</summary>
+                        <p>
+                        """)
+                    unchanged_tests = copy(unchanged_tests)     # only report the
+                    unchanged_tests[!, :source] .= "left_only"  # primary result
+                    foreach(reportrow, eachrow(unchanged_tests))
+                    println(io, """
+                        </p>
+                        </details>
+                        """)
+                end
+            else
+                # just report on all tests
+                println(io, "$(nrow(group)) packages $verb.")
+                foreach(reportrow, eachrow(group))
+
+                results["has_issues"] |= status in (:fail, :kill) && !isempty(group)
+            end
+
+            println(io)
+        end
+    end
+
+    # print summary of tested packages #
+    #----------------------------------#
+
+    o = count(==(:ok),      results["primary"].status)
+    s = count(==(:skip),    results["primary"].status)
+    f = count(==(:fail),    results["primary"].status)
+    k = count(==(:kill),    results["primary"].status)
+    x = nrow(results["primary"])
+
+    println(io, """
+                ## Summary
+
+                In total, $x packages were tested, out of which $o succeeded, $f failed $k got killed and $s were skipped.
+                """)
+
+    println(io)
+
+    # print build version info #
+    #--------------------------#
+
+    print(io, """
+              ## Version Info
+
+              #### Primary Build
+
+              ```
+              $(build.vinfo)
+              ```
+              """)
+
+    if hasagainstbuild
+        println(io)
+        print(io, """
+                  #### Comparison Build
+
+                  ```
+                  $(job.against.vinfo)
+                  ```
+                  """)
+    end
+
+    println(io, "<!-- Generated on $(now()) -->")
+
+    return nothing
+end
+
+# JSON Database Generation #
+#--------------------------#
+
+function printdb(io::IO, job::PkgEvalJob, results)
+    build = submission(job).build
+
+    # build information
+    json = Dict{String,Any}(
+        "build" => Dict(
+            "repo"  => build.repo,
+            "sha"   => build.sha,
+        )
+    )
+
+    # test results
+    tests = Dict()
+    for test in eachrow(results["primary"])
+        tests[test.uuid] = Dict(
+            "julia"         => test.julia,
+            "name"          => test.name,
+            "version"       => test.version,
+            "status"        => test.status,
+            "reason"        => test.reason,
+            "duration"      => test.duration,
+        )
+    end
+    json["tests"] = tests
+
+    JSON.print(io, json)
+
+    return
+end

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -173,7 +173,9 @@ function execute_tests!(job::PkgEvalJob, build::BuildRef, whichbuild::Symbol)
         pr = submission(job).prnumber
         if pr !== nothing
             try
-                julia = NewPkgEval.obtain_julia_build("pull/$pr/merge", build.repo)
+                # NOTE: the merge head only exists in the upstream Julia repository,
+                #       and not in the repository where the pull request originated.
+                julia = NewPkgEval.obtain_julia_build("pull/$pr/merge", "JuliaLang/julia")
             catch err
                 isa(err, LibGit2.GitError) || rethrow()
                 # there might not be a merge commit (e.g. in the case of merge conflicts)

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -546,9 +546,6 @@ function printreport(io::IO, job::PkgEvalJob, results)
                 # "against" entries are suffixed with `_1` because of the join
                 if test.source == "both"
                     against_log = "logs/$(test.name_1)/$(test.julia_1).log"
-                    if hasprevdate
-                        against_log = "../pkgeval-$(datedirname(results["previous_date"]))/$against_log"
-                    end
                     print(io, " vs. [$(test.name_1)$(verstr(test.version_1))]($against_log)")
 
                     print(io, " ($(NewPkgEval.statusses[test.status_1])")

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -608,13 +608,12 @@ function printreport(io::IO, job::PkgEvalJob, results)
     o = count(==(:ok),      results["primary"].status)
     s = count(==(:skip),    results["primary"].status)
     f = count(==(:fail),    results["primary"].status)
-    k = count(==(:kill),    results["primary"].status)
     x = nrow(results["primary"])
 
     println(io, """
                 ## Summary
 
-                In total, $x packages were tested, out of which $o succeeded, $f failed $k got killed and $s were skipped.
+                In total, $x packages were tested, out of which $o succeeded, $f failed and $s were skipped.
                 """)
 
     println(io)

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -499,6 +499,20 @@ function printreport(io::IO, job::PkgEvalJob, results)
         return nothing
     end
 
+    # print summary of tested packages #
+    #----------------------------------#
+
+    o = count(==(:ok),      results["primary"].status)
+    s = count(==(:skip),    results["primary"].status)
+    f = count(==(:fail),    results["primary"].status)
+    x = nrow(results["primary"])
+
+    println(io, """
+                In total, $x packages were tested, out of which $o succeeded, $f failed and $s were skipped.
+                """)
+
+    println(io)
+
     # print result list #
     #-------------------#
 
@@ -620,22 +634,6 @@ function printreport(io::IO, job::PkgEvalJob, results)
             println(io)
         end
     end
-
-    # print summary of tested packages #
-    #----------------------------------#
-
-    o = count(==(:ok),      results["primary"].status)
-    s = count(==(:skip),    results["primary"].status)
-    f = count(==(:fail),    results["primary"].status)
-    x = nrow(results["primary"])
-
-    println(io, """
-                ## Summary
-
-                In total, $x packages were tested, out of which $o succeeded, $f failed and $s were skipped.
-                """)
-
-    println(io)
 
     # print build version info #
     #--------------------------#

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -3,6 +3,7 @@ using DataFrames
 using Feather
 using JSON
 using Base: UUID
+using LibGit2
 
 
 ################################

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -302,7 +302,7 @@ function report(job::PkgEvalJob, results)
         reply_status(job, "error", "no tests were executed")
         reply_comment(job, "[Your test job]($(submission(job).url)) has completed, " *
                       "but no tests were actually executed. Perhaps your package selection " *
-                      "contains misspelled names? cc @maleadt")
+                      "contains misspelled names? cc @$(cfg.admin)")
     else
         #  prepare report + data and push it to report repo
         target_url = ""
@@ -351,10 +351,10 @@ function report(job::PkgEvalJob, results)
             reply_status(job, state, status, target_url)
             if isempty(target_url)
                 comment = "[Your test job]($(submission(job).url)) has completed, but " *
-                          "something went wrong when trying to upload the result data. cc @maleadt"
+                          "something went wrong when trying to upload the result data. cc @$(cfg.admin)"
             else
                 comment = "[Your test job]($(submission(job).url)) has completed - " *
-                          "$(status). A full report can be found [here]($(target_url)). cc @maleadt"
+                          "$(status). A full report can be found [here]($(target_url)). cc @$(cfg.admin)"
             end
             reply_comment(job, comment)
         end

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -615,6 +615,7 @@ function printreport(io::IO, job::PkgEvalJob, results)
             else
                 # just report on all tests
                 println(io, "$(nrow(group)) packages $verb.")
+                println(io)
                 reportgroup(group)
 
                 if status == :fail

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -188,7 +188,8 @@ function execute_tests!(job::PkgEvalJob, build::BuildRef, whichbuild::Symbol)
 
     # run tests
     results = withenv("CI" => true) do
-        NewPkgEval.run([julia], pkgs; ninstances=length(submission(job).config.cpus))
+        cpus = mycpus(submission(job).config)
+        NewPkgEval.run([julia], pkgs; ninstances=length(cpus))
     end
 
     # write logs

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -477,6 +477,15 @@ function printreport(io::IO, job::PkgEvalJob, results)
     # print summary of tested packages #
     #----------------------------------#
 
+    # we don't care about the distinction between failed and killed tests,
+    # so lump them together
+    for key in ("primary", "against", "previous")
+        if haskey(results, key)
+            df = results[key]
+            df[df[!, :status] .== :kill, :status] .= :fail
+        end
+    end
+
     o = count(==(:ok),      results["primary"].status)
     s = count(==(:skip),    results["primary"].status)
     f = count(==(:fail),    results["primary"].status)
@@ -490,18 +499,6 @@ function printreport(io::IO, job::PkgEvalJob, results)
 
     # print result list #
     #-------------------#
-
-    # TODO: in the case of a daily build, we might also have results["previous];
-    #       use that to report on package upgrades that caused test failures?
-
-    # we don't care about the distinction between failed and killed tests,
-    # so lump them together
-    for key in ("primary", "against", "previous")
-        if haskey(results, key)
-            df = results[key]
-            df[df[!, :status] .== :kill, :status] .= :fail
-        end
-    end
 
     if hasagainstbuild
         package_results = join(results["primary"], results["against"],

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -173,6 +173,11 @@ function execute_tests!(job::PkgEvalJob, build::BuildRef, whichbuild::Symbol)
                 # there might not be a merge commit (e.g. in the case of merge conflicts)
             end
         end
+        # NOTE: by calling obtain_julia_build with a ref (and not just a commit),
+        #       we'll get a versioninfo() that contains that ref. since that is useful,
+        #       BenchmarkJob should probably also use NewPkgEval's Julia builder,
+        #       at which point we can stop eagerly resolving Julia specifiers to
+        #       commit strings (branchref, tagref), or at least keeping more information.
     end
     if julia === nothing
         # fall back to the last commit in the PR

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -153,11 +153,6 @@ function execute_tests!(job::PkgEvalJob, builds::Dict{String,BuildRef}, results:
                     # there might not be a merge commit (e.g. in the case of merge conflicts)
                 end
             end
-            # NOTE: by calling obtain_julia_build with a ref (and not just a commit),
-            #       we'll get a versioninfo() that contains that ref. since that is useful,
-            #       BenchmarkJob should probably also use NewPkgEval's Julia builder,
-            #       at which point we can stop eagerly resolving Julia specifiers to
-            #       commit strings (branchref, tagref), or at least keeping more information.
         end
         if julia === nothing
             # fall back to the last commit in the PR

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -144,7 +144,7 @@ function retrieve_daily_tests!(results, key, cfg, date)
                 end
 
                 # read properties and create build ref
-                job = JSON.parsefile(joinpath(datapath, "job.json"))
+                job = JSON.parsefile(joinpath(datapath, "primary.json"))
                 build = BuildRef(job["build"]["repo"], job["build"]["sha"])
 
                 build
@@ -244,7 +244,7 @@ function execute_tests!(job::PkgEvalJob, build::BuildRef, whichbuild::Symbol)
         end
 
         # dict with job properties
-        open("job.json", "w") do io
+        open("$(whichbuild).json", "w") do io
             json = Dict{String,Any}(
                 "build" => Dict(
                     "repo"  => build.repo,

--- a/src/jobs/jobs.jl
+++ b/src/jobs/jobs.jl
@@ -12,5 +12,12 @@ reply_status(job::AbstractJob, args...; kwargs...) = reply_status(submission(job
 reply_comment(job::AbstractJob, args...; kwargs...) = reply_comment(submission(job), args...; kwargs...)
 upload_report_repo!(job::AbstractJob, args...; kwargs...) = upload_report_repo!(submission(job), args...; kwargs...)
 
+function branchref(config::Config, reponame::AbstractString, branchname::AbstractString)
+    shastr = GitHub.branch(reponame, branchname; auth=config.auth).commit.sha
+    return BuildRef(reponame, shastr)
+end
+
+datedirname(date::Dates.Date) = string("daily_", Dates.format(date, dateformat"yyyy_mm_dd"))
+
 include("BenchmarkJob.jl")
 include("PkgEvalJob.jl")

--- a/src/jobs/jobs.jl
+++ b/src/jobs/jobs.jl
@@ -22,7 +22,8 @@ function tagref(config::Config, reponame::AbstractString, tagname::AbstractStrin
     return BuildRef(reponame, shastr)
 end
 
-datedirname(date::Dates.Date) = string("daily_", Dates.format(date, dateformat"yyyy_mm_dd"))
+datedirname(date::Dates.Date) = joinpath(Dates.format(date, dateformat"yyyy-mm"),
+                                         Dates.format(date, dateformat"dd"))
 
 include("BenchmarkJob.jl")
 include("PkgEvalJob.jl")

--- a/src/jobs/jobs.jl
+++ b/src/jobs/jobs.jl
@@ -17,6 +17,11 @@ function branchref(config::Config, reponame::AbstractString, branchname::Abstrac
     return BuildRef(reponame, shastr)
 end
 
+function tagref(config::Config, reponame::AbstractString, tagname::AbstractString)
+    shastr = GitHub.tag(reponame, tagname; auth=config.auth).object["sha"]
+    return BuildRef(reponame, shastr)
+end
+
 datedirname(date::Dates.Date) = string("daily_", Dates.format(date, dateformat"yyyy_mm_dd"))
 
 include("BenchmarkJob.jl")

--- a/src/server.jl
+++ b/src/server.jl
@@ -56,6 +56,11 @@ function Base.run(server::Server, args...; kwargs...)
     # empty, then the task will call `yield` in order to avoid a deadlock.
     for (job_type, job_nodes) in server.config.nodes, node in job_nodes
         @async begin
+            # default to using all CPUs
+            if !haskey(server.config.cpus, getpid())
+                server.config.cpus[getpid()] = Base.OneTo(Sys.CPU_THREADS)
+            end
+
             try
                 while true
                     job = retrieve_job!(server.jobs, job_type, node == last(job_nodes))

--- a/src/server.jl
+++ b/src/server.jl
@@ -40,7 +40,7 @@ struct Server
             return HTTP.Response(202, "received job submission")
         end
 
-        listener = GitHub.CommentListener(handle, TRIGGER;
+        listener = GitHub.CommentListener(handle, config.trigger;
                                           auth = config.auth,
                                           secret = config.secret,
                                           repos = [config.trackrepo])

--- a/src/server.jl
+++ b/src/server.jl
@@ -113,7 +113,7 @@ function delegate_job(server::Server, job::AbstractJob, node)
                 message *= "Logs and partial data can be found [here]($(err.url))\n"
             end
         end
-        message *= "cc @ararslan"
+        message *= "cc @$(server.config.admin)"
         nodelog(server.config, node, err_str, error=(err, stacktrace(catch_backtrace())))
         reply_status(job, "error", err_str)
         reply_comment(job, message)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,6 +64,10 @@ build_test_submission(BenchmarkJob, "@nanosoldier `runbenchmarks(ALL; isdaily = 
 build_test_submission(BenchmarkJob, "@nanosoldier `runbenchmarks(\"tag\"; isdaily = true, vs = \"JuliaLang/julia:master\")`")
 build_test_submission(BenchmarkJob, "@nanosoldier `runbenchmarks($tagpred; isdaily = true, vs = \"JuliaLang/julia:master\")`")
 
+build_test_submission(BenchmarkJob, "@nanosoldier `runbenchmarks(ALL, vs = \"JuliaLang/julia#v1.0.0\")`")
+build_test_submission(BenchmarkJob, "@nanosoldier `runbenchmarks(\"tag\", vs = \"JuliaLang/julia#v1.0.0\")`")
+build_test_submission(BenchmarkJob, "@nanosoldier `runbenchmarks($tagpred, vs = \"JuliaLang/julia#v1.0.0\")`")
+
 build_test_submission(PkgEvalJob, "@nanosoldier `runtests(ALL)`")
 build_test_submission(PkgEvalJob, "@nanosoldier `runtests(\"pkg\")`")
 build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel)`")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ Intel(R) Core(TM) i5-4288U CPU @ 2.60GHz:
 
 primary = BuildRef("ararslan/julia", "25c3659d6cec2ebf6e6c7d16b03adac76a47b42a", vinfo)
 against = BuildRef("JuliaLang/julia", "bb73f3489d837e3339fce2c1aab283d3b2e97a4c", vinfo*"_against")
-config = Config("user", Dict(Any => [1]), [1], GitHub.AnonymousAuth(), "test");
+config = Config("user", Dict(Any => [getpid()]), GitHub.AnonymousAuth(), "test");
 tagpred = "ALL && !(\"tag1\" || \"tag2\")"
 pkgsel = "[\"Example\"]"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ Intel(R) Core(TM) i5-4288U CPU @ 2.60GHz:
 
 primary = BuildRef("ararslan/julia", "25c3659d6cec2ebf6e6c7d16b03adac76a47b42a", vinfo)
 against = BuildRef("JuliaLang/julia", "bb73f3489d837e3339fce2c1aab283d3b2e97a4c", vinfo*"_against")
-config = Config("user", [1], [1], GitHub.AnonymousAuth(), "test");
+config = Config("user", Dict(Any => [1]), [1], GitHub.AnonymousAuth(), "test");
 tagpred = "ALL && !(\"tag1\" || \"tag2\")"
 pkgsel = "[\"Example\"]"
 
@@ -80,32 +80,47 @@ non_daily_job = build_test_submission(BenchmarkJob, "@nanosoldier `runbenchmarks
 daily_job = build_test_submission(BenchmarkJob, "@nanosoldier `runbenchmarks(ALL, isdaily = true)`")
 
 queue = [daily_job, daily_job]
-job = Nanosoldier.retrieve_job!(queue, true)
+job = Nanosoldier.retrieve_job!(queue, BenchmarkJob, true)
 @test job !== nothing && job.isdaily
 @test length(queue) == 1
 
 queue = [non_daily_job, daily_job]
-job = Nanosoldier.retrieve_job!(queue, true)
+job = Nanosoldier.retrieve_job!(queue, BenchmarkJob, true)
 @test job !== nothing && !job.isdaily
 @test length(queue) == 1
 
 queue = [daily_job, non_daily_job]
-job = Nanosoldier.retrieve_job!(queue, true)
+job = Nanosoldier.retrieve_job!(queue, BenchmarkJob, true)
 @test job !== nothing && job.isdaily
 @test length(queue) == 1
 
 queue = [daily_job, daily_job]
-job = Nanosoldier.retrieve_job!(queue, false)
+job = Nanosoldier.retrieve_job!(queue, BenchmarkJob, false)
 @test job === nothing
 @test length(queue) == 2
 
 queue = [non_daily_job, daily_job]
-job = Nanosoldier.retrieve_job!(queue, false)
+job = Nanosoldier.retrieve_job!(queue, BenchmarkJob, false)
 @test job !== nothing && !job.isdaily
 @test length(queue) == 1
 
 queue = [daily_job, non_daily_job]
-job = Nanosoldier.retrieve_job!(queue, false)
+job = Nanosoldier.retrieve_job!(queue, BenchmarkJob, false)
+@test job !== nothing && !job.isdaily
+@test length(queue) == 1
+
+queue = [daily_job, non_daily_job]
+job = Nanosoldier.retrieve_job!(queue, PkgEvalJob, true)
+@test job === nothing
+@test length(queue) == 2
+
+queue = [daily_job, non_daily_job]
+job = Nanosoldier.retrieve_job!(queue, BenchmarkJob, true)
+@test job !== nothing && job.isdaily
+@test length(queue) == 1
+
+queue = [daily_job, non_daily_job]
+job = Nanosoldier.retrieve_job!(queue, Any, false)
 @test job !== nothing && !job.isdaily
 @test length(queue) == 1
 


### PR DESCRIPTION
This PR adds a PkgEvalJob to periodically, or on demand, run tests of all packages in General against specific Julia versions. It is build on [NewPkgEval](https://github.com/JuliaComputing/NewPkgEval.jl), and most of the changes in this PR are confined to `PkgEvalJob.jl`.

I tried to make the job look like the existing BenchmarkJob as much as possible, so that it is possible to extract common functionality after this PR is merged. This includes the concept of daily builds, the way reports are generated and formatted, including a compressed data dump, etc.

At the same time, PkgEvalJob has some specific dependencies (julia 1.3, NewPkgEval#master, BinaryBuilder#master) and is likely to be under development for a while, so I don't think it's worth to try and integrate this into the existing infrastructure on the MIT cluster. I did some minor refactoring to facilitate running as a separate instance, and I'm currently trial-running this PR on arctic1.

Some example output: https://github.com/maleadt/julia/commit/9babbf5dc6d2d08b9ed422386830460516cb8aed

I also added support for referencing a tag using `#`. It would probably be good to unify this syntax with Pkg's though (`#` for branches, `@` for versions == tags), but I kept it non-breaking for now. Finally, I added a Project.toml and Manifest, but I'm not sure what the exact set-up on the cluster is.