### PR TITLE
[RFC] Customize the order in which results are printed

### DIFF
--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -504,7 +504,7 @@ end
 const REGRESS_MARK = ":x:"
 const IMPROVE_MARK = ":white_check_mark:"
 
-function printreport(io::IO, job::BenchmarkJob, results)
+function printreport(io::IO, job::BenchmarkJob, results; sortby = string∘first)
     build = submission(job).build
     buildname = string(build.repo, SHA_SEPARATOR, build.sha)
     buildlink = "https://github.com/$(build.repo)/commit/$(build.sha)"
@@ -605,7 +605,7 @@ function printreport(io::IO, job::BenchmarkJob, results)
     entries = BenchmarkTools.leaves(tablegroup)
 
     try
-        entries = entries[sortperm(map(string∘first, entries))]
+        entries = entries[sortperm(map(sortby, entries))]
     catch
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,6 +139,11 @@ results["judged"] = BenchmarkTools.judge(results["primary"], results["against"])
 
 @test begin
     mdpath = joinpath(@__DIR__, "report.md")
+    sortbyratio = x -> -(x[2].ratio.time)
+    open(mdpath, "r") do file
+        read(file, String) == sprint(io -> Nanosoldier.printreport(io, job, results; sortby=sortbyratio))
+    end
+    rm(mdpath; force = true)
     open(mdpath, "r") do file
         read(file, String) == sprint(io -> Nanosoldier.printreport(io, job, results))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,12 +139,10 @@ results["judged"] = BenchmarkTools.judge(results["primary"], results["against"])
 
 @test begin
     mdpath = joinpath(@__DIR__, "report.md")
-    sortbyratio = x -> -(x[2].ratio.time)
-    open(mdpath, "r") do file
-        read(file, String) == sprint(io -> Nanosoldier.printreport(io, job, results; sortby=sortbyratio))
-    end
-    rm(mdpath; force = true)
     open(mdpath, "r") do file
         read(file, String) == sprint(io -> Nanosoldier.printreport(io, job, results))
+    end
+    open(mdpath, "r") do file
+        read(file, String) == sprint(io -> Nanosoldier.printreport(io, job, results; sortby = x -> -(x[2].ratio.time)))
     end
 end


### PR DESCRIPTION
This pull request allows you to customize the order in which results are printed in the Markdown table.

The default behavior is preserved, so this is a non-breaking change.