### PR TITLE
Make CPU collection 0-indexed

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -59,4 +59,4 @@ function nodelog(config::Config, node, message; error=nothing)
 end
 
 # the list of CPUs for a given node
-mycpus(config::Config, node=getpid()) = get(config.cpus, node, Base.OneTo(Sys.CPU_THREADS))
+mycpus(config::Config, node=getpid()) = get(config.cpus, node, 0:(Sys.CPU_THREADS-1))


### PR DESCRIPTION
The daily benchmark is running into a problem with `cset`: https://github.com/JuliaLang/julia/commit/113afd93092645e3939737c5c1c487edb7a62094#commitcomment-43140847

Looks like `cset` expects CPU indices to be zero-indexed, so 0-3 instead of 1-4.

```sh
$ sudo cset shield -c 1,2,3,4 -k on
cset: **> CPUSPEC "1,2,3,4" specifies higher max(4) than available(3)
```