### PR TITLE
Don't include the report commit in the URL.

### DIFF
--- a/src/submission.jl
+++ b/src/submission.jl
@@ -129,5 +129,5 @@ function upload_report_repo!(sub::JobSubmission, markdownpath, message)
         run(`git push`)
         return headsha
     end
-    return "https://github.com/$(reportrepo(cfg))/blob/$(sha)/$(markdownpath)"
+    return "https://github.com/$(reportrepo(cfg))/blob/master/$(markdownpath)"
 end


### PR DESCRIPTION
Ref https://github.com/JuliaCI/Nanosoldier.jl/pull/80#issuecomment-721190282, otherwise we can't rewrite the reports repo's history without breaking all those URLs.