### PR TITLE
Use XZ to compress tarballs.

### DIFF
--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -466,7 +466,7 @@ function report(job::BenchmarkJob, results)
             nodelog(cfg, node, "...tarring data...")
             cd(tmpdir(job)) do
                 run(`tar -cf data.tar data`)
-                run(`xz --compress -9 --extreme --threads=0 data.tar`)
+                run(`xz --compress -9 --extreme data.tar`)
                 rm(tmpdatadir(job), recursive=true)
             end
             nodelog(cfg, node, "...moving $(tmpdir(job)) to $(reportdir(job))...")

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -399,7 +399,8 @@ function report(job::PkgEvalJob, results)
             end
             nodelog(cfg, node, "...tarring data...")
             cd(tmpdir(job)) do
-                run(`tar -zcf data.tar.gz data`)
+                run(`tar -cf data.tar data`)
+                run(`xz --compress -9 --extreme --threads=0 data.tar`)
                 rm(tmpdatadir(job), recursive=true)
             end
             nodelog(cfg, node, "...moving $(tmpdir(job)) to $(reportdir(job))...")

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -400,7 +400,7 @@ function report(job::PkgEvalJob, results)
             nodelog(cfg, node, "...tarring data...")
             cd(tmpdir(job)) do
                 run(`tar -cf data.tar data`)
-                run(`xz --compress -9 --extreme --threads=0 data.tar`)
+                run(`xz --compress -9 --extreme data.tar`)
                 rm(tmpdatadir(job), recursive=true)
             end
             nodelog(cfg, node, "...moving $(tmpdir(job)) to $(reportdir(job))...")


### PR DESCRIPTION
This saves 50% on the data tarball sizes.

cc @christopher-dG this needs `xz-utils` on the nanosoldier master node.