### PR TITLE
Upload logs as UTF-8

### DIFF
--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -243,7 +243,7 @@ function execute_tests!(job::PkgEvalJob, builds::Dict, flags::Dict, results::Dic
                                   "$(test.name).$(test.julia).log",
                                   Dict("body"       => test.log,
                                        "x-amz-acl"  => "public-read",
-                                       "headers"    => Dict("Content-Type"=>"text/plain")))
+                                       "headers"    => Dict("Content-Type"=>"text/plain; charset=utf-8")))
                 end
             end
         else


### PR DESCRIPTION
Pkg uses lots of UTF-8, but browsers aren't always great about auto-detecting formats (or might default to something else without even trying).