### PR TITLE
Do not create the ``Nanosoldier/PkgEval`` GitHub commit status (but still post GitHub commit comments)

### DIFF
--- a/src/submission.jl
+++ b/src/submission.jl
@@ -108,8 +108,10 @@ function reply_status(sub::JobSubmission, context, state, description, url=nothi
                   "context" => context,
                   "description" => snip(description, 140))
     url !== nothing && (params["target_url"] = url)
-    return GitHub.create_status(sub.config.trackrepo, sub.statussha;
-                                auth = sub.config.auth, params = params)
+    
+    # return GitHub.create_status(sub.config.trackrepo, sub.statussha;
+    #                             auth = sub.config.auth, params = params)
+    return nothing
 end
 
 function reply_comment(sub::JobSubmission, message::AbstractString)


### PR DESCRIPTION
The `Nanosoldier/PkgEval`  GitHub commit status is almost always a "fail" (red X). This means that the overall commit status for `master` is a red X, which makes it seem like `master` is broken.

This PR disables the commit status updates, while preserving the commit comments.