### PR TITLE
Add the `Base.copy(::BuildRef)` method , and remove all uses of `deepcopy`

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -10,6 +10,8 @@ end
 
 BuildRef(repo, sha) = BuildRef(repo, sha, "retrieving versioninfo() failed")
 
+Base.copy(x::BuildRef) = BuildRef(x.repo, x.sha, x.vinfo)
+
 function Base.:(==)(a::BuildRef, b::BuildRef)
     return (a.repo == b.repo &&
             a.sha == b.sha &&

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -65,7 +65,7 @@ function BenchmarkJob(submission::JobSubmission)
             againstrepo = isempty(reporef) ? submission.config.trackrepo : reporef
             againstbuild = tagref(submission.config, againstrepo, againsttag)
         elseif againststr == SPECIAL_SELF
-            againstbuild = deepcopy(submission.build)
+            againstbuild = copy(submission.build)
         else
             error("invalid argument to `vs` keyword")
         end

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -73,7 +73,7 @@ function PkgEvalJob(submission::JobSubmission)
             againstrepo = isempty(reporef) ? submission.config.trackrepo : reporef
             againstbuild = tagref(submission.config, againstrepo, againsttag)
         elseif againststr == SPECIAL_SELF
-            againstbuild = deepcopy(submission.build)
+            againstbuild = copy(submission.build)
         else
             error("invalid argument to `vs` keyword")
         end


### PR DESCRIPTION
Inspired by Jeff's recent comments (https://github.com/JuliaLang/julia/issues/42796#issuecomment-951232853), I have:

1. Added the `Base.copy(::BuildRef)` method.
2. Removed all uses of `deepcopy` from this package.