### PR TITLE
Updates for PkgEval

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,13 +1,14 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.6.6"
+julia_version = "1.8.0-rc3"
 manifest_format = "2.0"
+project_hash = "d42e4897550ad192083d96fdc12bad0fd230a347"
 
 [[deps.AWS]]
-deps = ["Base64", "Compat", "Dates", "Downloads", "GitHub", "HTTP", "IniFile", "JSON", "MbedTLS", "Mocking", "OrderedCollections", "Retry", "Sockets", "URIs", "UUIDs", "XMLDict"]
-git-tree-sha1 = "ee0efa566d172a2a282338566d6a7167823ecb82"
+deps = ["Base64", "Compat", "Dates", "Downloads", "GitHub", "HTTP", "IniFile", "JSON", "MbedTLS", "Mocking", "OrderedCollections", "Random", "Sockets", "URIs", "UUIDs", "XMLDict"]
+git-tree-sha1 = "378e85b1354746ea613f4a3f388d105168cc4248"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
-version = "1.74.1"
+version = "1.75.1"
 
 [[deps.ArgParse]]
 deps = ["Logging", "TextWrap"]
@@ -17,6 +18,7 @@ version = "1.1.4"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.1"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -54,10 +56,10 @@ uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
 version = "0.4.8"
 
 [[deps.BinaryBuilderBase]]
-deps = ["CodecZlib", "Downloads", "InteractiveUtils", "JSON", "LibGit2", "Libdl", "Logging", "OutputCollectors", "Pkg", "Random", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "UUIDs", "p7zip_jll", "pigz_jll"]
-git-tree-sha1 = "a7d9c9f209f47a86622ec2bc019359b41db33d0b"
+deps = ["CodecZlib", "Downloads", "InteractiveUtils", "JSON", "LibGit2", "LibGit2_jll", "Libdl", "Logging", "OrderedCollections", "OutputCollectors", "Pkg", "ProgressMeter", "Random", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "UUIDs", "p7zip_jll", "pigz_jll"]
+git-tree-sha1 = "fa26ae2e67151f71070a259cf303fd5beb3fa010"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
-version = "1.3.0"
+version = "1.13.0"
 
 [[deps.CategoricalArrays]]
 deps = ["DataAPI", "Future", "Missings", "Printf", "Requires", "Statistics", "Unicode"]
@@ -79,9 +81,14 @@ version = "0.8.6"
 
 [[deps.Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "b153278a25dd42c65abbf4e62344f9d22e59191b"
+git-tree-sha1 = "9be8be1d8a6f44b96482c8af52238ea7987da3e3"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.43.0"
+version = "3.45.0"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "0.5.2+0"
 
 [[deps.Crayons]]
 git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
@@ -101,9 +108,9 @@ version = "1.3.4"
 
 [[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "cc1a8e22627f33c789ab60b36a9132ac050bbf75"
+git-tree-sha1 = "d1fff3a548102f48987a52a2e0d114fa97d730f0"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.12"
+version = "0.18.13"
 
 [[deps.DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -123,8 +130,15 @@ deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[deps.Downloads]]
-deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[deps.Expat_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "bad72f730e9e91c08d9427d5e8db95478a3c323d"
+uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
+version = "2.4.8+0"
 
 [[deps.ExprTools]]
 git-tree-sha1 = "56559bbef6ca5ea0c0818fa5c90320398a6fbf8d"
@@ -145,9 +159,9 @@ version = "0.5.10"
 
 [[deps.FileIO]]
 deps = ["Pkg", "Requires", "UUIDs"]
-git-tree-sha1 = "9267e5f50b0e12fdfd5a2455534345c4cf2c7f7a"
+git-tree-sha1 = "94f5101b96d2d968ace56f7f2db19d0a5f592e28"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-version = "1.14.0"
+version = "1.15.0"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
@@ -168,6 +182,18 @@ version = "0.4.2"
 deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 
+[[deps.Gettext_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "XML2_jll"]
+git-tree-sha1 = "9b02998aba7bf074d14de89f9d37ca24a1a0b046"
+uuid = "78b55507-aeef-58d4-861c-77aaff3498b1"
+version = "0.21.0+0"
+
+[[deps.Git]]
+deps = ["Git_jll"]
+git-tree-sha1 = "d7bffc3fe097e9589145493c08c41297b457e5d0"
+uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
+version = "1.2.1"
+
 [[deps.GitForge]]
 deps = ["Dates", "HTTP", "JSON2"]
 git-tree-sha1 = "0e6b8635059d6ac9e421825e75f8fca170f557d2"
@@ -176,9 +202,15 @@ version = "0.1.7"
 
 [[deps.GitHub]]
 deps = ["Base64", "Dates", "HTTP", "JSON", "MbedTLS", "Sockets", "SodiumSeal", "URIs"]
-git-tree-sha1 = "056781ae7b953289778408b136f8708a46837979"
+git-tree-sha1 = "f1d3170f588c7610b568c9a97971915100dd51e8"
 uuid = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
-version = "5.7.2"
+version = "5.7.3"
+
+[[deps.Git_jll]]
+deps = ["Artifacts", "Expat_jll", "Gettext_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libiconv_jll", "OpenSSL_jll", "PCRE2_jll", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "6e93d42b97978709e9c941fa43d0f01701f0d290"
+uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
+version = "2.34.1+0"
 
 [[deps.HTTP]]
 deps = ["Base64", "Dates", "IniFile", "Logging", "MbedTLS", "NetworkOptions", "Sockets", "URIs"]
@@ -247,18 +279,26 @@ uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.3"
 
 [[deps.LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "7.83.1+1"
 
 [[deps.LibGit2]]
 deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.3.0+0"
+
 [[deps.LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.10.2+0"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -270,7 +310,7 @@ uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
 version = "1.16.1+1"
 
 [[deps.LinearAlgebra]]
-deps = ["Libdl"]
+deps = ["Libdl", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.Logging]]
@@ -278,9 +318,9 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[deps.LoggingExtras]]
 deps = ["Dates", "Logging"]
-git-tree-sha1 = "e9437ef53c3b29a838f4635e748bb38d29d11384"
+git-tree-sha1 = "5d4d2d9904227b8bd66386c1138cf4d5ffa826bf"
 uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
-version = "0.4.8"
+version = "0.4.9"
 
 [[deps.MacroTools]]
 deps = ["Markdown", "Random"]
@@ -293,14 +333,15 @@ deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[deps.MbedTLS]]
-deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
-git-tree-sha1 = "1c38e51c3d08ef2278062ebceade0e46cefc96fe"
+deps = ["Dates", "MbedTLS_jll", "MozillaCACerts_jll", "Random", "Sockets"]
+git-tree-sha1 = "14cb991ee7ccc6dabda93d310400575c3cae435b"
 uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-version = "1.0.3"
+version = "1.1.2"
 
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.0+0"
 
 [[deps.Missings]]
 deps = ["DataAPI"]
@@ -319,12 +360,13 @@ version = "0.7.3"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2022.2.1"
 
 [[deps.Mustache]]
 deps = ["Printf", "Tables"]
-git-tree-sha1 = "bfbd6fb946d967794498790aa7a0e6cdf1120f41"
+git-tree-sha1 = "1e566ae913a57d0062ff1af54d2697b9344b99cd"
 uuid = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
-version = "1.0.13"
+version = "1.0.14"
 
 [[deps.Mux]]
 deps = ["AssetRegistry", "Base64", "HTTP", "Hiccup", "Pkg", "Sockets", "WebSockets"]
@@ -334,12 +376,24 @@ version = "0.7.6"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
 
 [[deps.ObjectFile]]
 deps = ["Reexport", "StructIO"]
 git-tree-sha1 = "55ce61d43409b1fb0279d1781bf3b0f22c83ab3b"
 uuid = "d8793406-e978-5875-9003-1fc021f44a92"
 version = "0.3.7"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.20+0"
+
+[[deps.OpenSSL_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "e60321e3f2616584ff98f0a4f18d98ae6f89bbb3"
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "1.1.17+0"
 
 [[deps.OrderedCollections]]
 git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
@@ -351,6 +405,11 @@ git-tree-sha1 = "5d3f2b3b2e2a9d7d6f1774c78e94530ac7f360cc"
 uuid = "6c11c7d4-943b-4e2b-80de-f2cfc2930a8c"
 version = "0.1.1"
 
+[[deps.PCRE2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
+version = "10.40.0+0"
+
 [[deps.Parameters]]
 deps = ["OrderedCollections", "UnPack"]
 git-tree-sha1 = "34c0e9ad262e5f7fc75b10a9952ca7692cfc5fbe"
@@ -359,9 +418,9 @@ version = "0.12.3"
 
 [[deps.Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "1285416549ccfcdf0c50d4997a94331e88d68413"
+git-tree-sha1 = "0044b23da09b5608b4ecacb4e5e6c6332f833a7e"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.3.1"
+version = "2.3.2"
 
 [[deps.Pidfile]]
 deps = ["FileWatching", "Test"]
@@ -372,14 +431,15 @@ version = "1.3.0"
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.8.0"
 
 [[deps.PkgEval]]
-deps = ["BinaryBuilder", "DataFrames", "Dates", "Downloads", "LazyArtifacts", "LibGit2", "Pkg", "ProgressMeter", "Random", "SHA", "Sandbox"]
-git-tree-sha1 = "c96bdf9b10982dcdca90c49a91982e8f5be44472"
-repo-rev = "14f4d1ee"
+deps = ["BinaryBuilder", "DataFrames", "Dates", "Downloads", "Git", "JSON", "LazyArtifacts", "Pkg", "ProgressMeter", "Random", "Sandbox", "Scratch"]
+git-tree-sha1 = "9ef787ac2c844501877098e3593b6bfcd400fa9f"
+repo-rev = "938faac3ea65d754f1622e305a81db9c0ea52bb9"
 repo-url = "https://github.com/JuliaCI/PkgEval.jl"
 uuid = "9f2e2246-6dce-11e8-3d98-4b291446da6e"
-version = "0.1.0"
+version = "0.2.0"
 
 [[deps.PkgLicenses]]
 deps = ["Test"]
@@ -424,7 +484,7 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.Random]]
-deps = ["Serialization"]
+deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[deps.Reexport]]
@@ -450,25 +510,21 @@ git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
 version = "1.3.0"
 
-[[deps.Retry]]
-git-tree-sha1 = "41ac127cd281bb33e42aba46a9d3b25cd35fc6d5"
-uuid = "20febd7b-183b-5ae2-ac4a-720e7ce64774"
-version = "0.4.1"
-
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
 
 [[deps.Sandbox]]
 deps = ["LazyArtifacts", "Libdl", "Preferences", "Random", "SHA", "Scratch", "TOML", "Tar", "Tar_jll", "UserNSSandbox_jll"]
-git-tree-sha1 = "59bbd36ca0f90d5fbf559e7475be8db8523761d9"
+git-tree-sha1 = "6f63cf7ba2dc84f3bd71a7214cc5dca241487c8d"
 uuid = "9307e30f-c43e-9ca7-d17c-c2dc59df670d"
-version = "1.3.0"
+version = "1.4.0"
 
 [[deps.Scratch]]
 deps = ["Dates"]
-git-tree-sha1 = "0b4b7f1393cff97c33891da2a0bf69c6ed241fda"
+git-tree-sha1 = "f94f779c94e58bf9ea243e77a37e16d9de9126bd"
 uuid = "6c6a2e73-6563-6170-7368-637461726353"
-version = "1.1.0"
+version = "1.1.1"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -514,6 +570,7 @@ version = "0.3.0"
 [[deps.TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.0"
 
 [[deps.TableTraits]]
 deps = ["IteratorInterfaceExtensions"]
@@ -530,6 +587,7 @@ version = "1.7.0"
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
 
 [[deps.Tar_jll]]
 deps = ["Artifacts", "Attr_jll", "JLLWrappers", "Libdl", "Pkg"]
@@ -559,9 +617,9 @@ uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 version = "0.9.6"
 
 [[deps.URIs]]
-git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
+git-tree-sha1 = "e59ecc5a41b000fa94423a578d29290c7266fc10"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.3.0"
+version = "1.4.0"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
@@ -577,9 +635,9 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [[deps.UserNSSandbox_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "ebd94673ad737817c4f837250ea4c15d36a63e1d"
+git-tree-sha1 = "651b582371b815cdd193df12806463550f60666b"
 uuid = "b88861f7-1d72-59dd-91e7-a8cc876a4984"
-version = "2022.3.30+0"
+version = "2022.8.1+1"
 
 [[deps.WebSockets]]
 deps = ["Base64", "Dates", "HTTP", "Logging", "Sockets"]
@@ -589,9 +647,9 @@ version = "1.5.9"
 
 [[deps.XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "1acf5bdf07aa0907e0a37d3718bb88d4b687b74a"
+git-tree-sha1 = "58443b63fb7e465a8a7210828c91c08b92132dff"
 uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.9.12+0"
+version = "2.9.14+0"
 
 [[deps.XMLDict]]
 deps = ["EzXML", "IterTools", "OrderedCollections"]
@@ -614,12 +672,18 @@ version = "4.3.4+0"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.12+3"
 
 [[deps.ghr_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "f5c8cb306d4fe2d1fff90443a088fc5ba536c134"
 uuid = "07c12ed4-43bc-5495-8a2a-d5838ef8d533"
 version = "0.13.0+1"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.1.1+0"
 
 [[deps.libsodium_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -630,10 +694,12 @@ version = "1.0.20+0"
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.47.0+0"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+0"
 
 [[deps.pigz_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.8.0-rc3"
 manifest_format = "2.0"
-project_hash = "d42e4897550ad192083d96fdc12bad0fd230a347"
+project_hash = "d5fd0cd13d3b5e6693862222e1b443e5d109c4c0"
 
 [[deps.AWS]]
 deps = ["Base64", "Compat", "Dates", "Downloads", "GitHub", "HTTP", "IniFile", "JSON", "MbedTLS", "Mocking", "OrderedCollections", "Random", "Sockets", "URIs", "UUIDs", "XMLDict"]

--- a/Project.toml
+++ b/Project.toml
@@ -16,10 +16,12 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Pidfile = "fa939f87-e72e-5be4-a000-7fc836dbe307"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PkgEval = "9f2e2246-6dce-11e8-3d98-4b291446da6e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
+PkgEval = "0.2"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ Pidfile = "fa939f87-e72e-5be4-a000-7fc836dbe307"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PkgEval = "9f2e2246-6dce-11e8-3d98-4b291446da6e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 
 [compat]
 PkgEval = "0.2"

--- a/bin/run_base_ci.jl
+++ b/bin/run_base_ci.jl
@@ -9,7 +9,6 @@ secret = GITHUB_SECRET
 port = Int(0xffff)
 
 config = Nanosoldier.Config("nanosoldier-worker", nodes, auth, secret;
-                            workdir = joinpath(@__DIR__, "workdir"),
                             trackrepo = "JuliaLang/julia",
                             reportrepo = "JuliaCI/NanosoldierReports",
                             testmode = false)

--- a/bin/run_base_pkgeval.jl
+++ b/bin/run_base_pkgeval.jl
@@ -8,7 +8,6 @@ auth = GitHub.authenticate(ENV["GITHUB_AUTH"])
 secret = ENV["GITHUB_SECRET"]
 
 config = Nanosoldier.Config(ENV["USER"], nodes, auth, secret;
-                            workdir = joinpath(@__DIR__, "workdir"),
                             trackrepo = "JuliaLang/julia",
                             reportrepo = "JuliaCI/NanosoldierReports",
                             trigger = r"\@nanosoldier\s*`runtests\(.*?\)`",

--- a/bin/setup_test_ci.jl
+++ b/bin/setup_test_ci.jl
@@ -8,7 +8,6 @@ auth = GitHub.authenticate(ENV["GITHUB_AUTH"])
 secret = ENV["GITHUB_SECRET"]
 
 config = Nanosoldier.Config("nanosoldier-worker", nodes, auth, secret;
-                            workdir = joinpath(homedir(), "test_workdir"),
                             trackrepo = "vtjnash/julia",
                             reportrepo = "vtjnash/NanosoldierReports",
                             admin = "vtjnash",

--- a/provision-server.sh
+++ b/provision-server.sh
@@ -25,9 +25,6 @@ sudo -u nanosoldier ssh -T git@github.com || true
 [ -d PkgEval.jl ] || git clone https://github.com/JuliaCI/PkgEval.jl
 sudo -u nanosoldier julia-$VERSION/bin/julia --project=$HERE -e 'using Pkg; Pkg.instantiate()'
 
-[ -d workdir ] || mkdir workdir
-sudo chown nanosoldier:nanosoldier workdir
-
 set +v
 
 echo

--- a/src/Nanosoldier.jl
+++ b/src/Nanosoldier.jl
@@ -1,6 +1,6 @@
 module Nanosoldier
 
-using Dates, Distributed, Printf, InteractiveUtils, Pidfile
+using Dates, Distributed, Printf, InteractiveUtils, Pidfile, Scratch
 import GitHub, BenchmarkTools, JSON, HTTP, AWS
 
 AWS.@service S3
@@ -9,6 +9,8 @@ const SHA_SEPARATOR = '@'
 const BRANCH_SEPARATOR = ':'
 const TAG_SEPARATOR = '#'
 const SPECIAL_SELF = "%self"
+
+workdir = ""
 
 #####################
 # utility functions #
@@ -62,5 +64,9 @@ include("build.jl")
 include("submission.jl")
 include("jobs/jobs.jl")
 include("server.jl")
+
+function __init__()
+    global workdir = @get_scratch!("workdir")
+end
 
 end # module

--- a/src/build.jl
+++ b/src/build.jl
@@ -45,14 +45,14 @@ end
 function build_julia!(config::Config, build::BuildRef, logpath, prnumber::Union{Int,Nothing}=nothing)
     # make a temporary workdir for our build
     gid = parse(Int, readchomp(`id -g $(config.user)`))
-    tmpdir = mktempdir(workdir(config))
+    tmpdir = mktempdir(workdir)
     chown(tmpdir, -1, gid)
     chmod(tmpdir, 0o775)
     srcdir = joinpath(tmpdir, "julia")
     run(`sudo -n -u $(config.user) -- mkdir -m 775 $srcdir`)
     chmod(tmpdir, 0o555)
 
-    mirrordir = joinpath(workdir(config), "mirrors", split(config.trackrepo, "/")...)
+    mirrordir = joinpath(workdir, "mirrors", split(config.trackrepo, "/")...)
     mkpath(dirname(mirrordir), mode=0o755)
     mkpidlock(mirrordir * ".lock") do
         if ispath(mirrordir)
@@ -86,8 +86,8 @@ function build_julia!(config::Config, build::BuildRef, logpath, prnumber::Union{
     outfile = joinpath(logpath, string(logname, ".out"))
     errfile = joinpath(logpath, string(logname, ".err"))
 
-    mirrordir1 = joinpath(workdir(config), "srccache", "deps")
-    mirrordir2 = joinpath(workdir(config), "srccache", "stdlib")
+    mirrordir1 = joinpath(workdir, "srccache", "deps")
+    mirrordir2 = joinpath(workdir, "srccache", "stdlib")
     mkpath(mirrordir1, mode=0o755)
     mkpath(mirrordir2, mode=0o755)
     srccache1 = joinpath(srcdir, "deps", "srccache")

--- a/src/config.jl
+++ b/src/config.jl
@@ -7,13 +7,11 @@ struct Config
     trackrepo::String               # the main Julia repo tracked by the server
     reportrepo::String              # the repo to which result reports are posted
     trigger::Regex                  # a regular expression to match comments against
-    workdir::String                 # the server's work directory
     admin::String                   # GitHub handle of the server administrator
     bucket::Union{Nothing,String}   # AWS bucket to upload large files too
     testmode::Bool                  # if true, jobs will run as test jobs
 
     function Config(user, nodes, auth, secret;
-                    workdir = pwd(),
                     cpus = Dict{Int,Vector{Int}}(),
                     trackrepo = "JuliaLang/julia",
                     reportrepo = "JuliaCI/NanosoldierReports",
@@ -23,23 +21,20 @@ struct Config
                     testmode = false)
         isempty(nodes) && throw(ArgumentError("need at least one node to work on"))
         return new(user, nodes, cpus, auth, secret, trackrepo,
-                   reportrepo, trigger, workdir, admin, bucket, testmode)
+                   reportrepo, trigger, admin, bucket, testmode)
     end
 end
-
-# the shared space in which child nodes can work
-workdir(config::Config) = config.workdir
 
 # the report repository
 reportrepo(config::Config) = config.reportrepo
 
 # the local directory of the report repository
-reportdir(config::Config) = joinpath(workdir(config), split(reportrepo(config), "/")[2])
+reportdir(config::Config) = joinpath(workdir, split(reportrepo(config), "/")[2])
 
 persistdir!(path) = (isdir(path) || mkdir(path); return path)
 
 function persistdir!(config::Config)
-    persistdir!(workdir(config))
+    persistdir!(workdir)
     if isdir(reportdir(config))
         gitreset!(reportdir(config))
     else
@@ -54,8 +49,8 @@ function nodelog(config::Config, node, message; error=nothing)
     else
         @info "[Node $node | $time]: $message"
     end
-    persistdir!(workdir(config))
-    path = joinpath(workdir(config), "node$(node).log")
+    persistdir!(workdir)
+    path = joinpath(workdir, "node$(node).log")
     open(path, "a") do file
         chmod(path, 0o660)
         println(file, time, " | ", node, " | ", message)

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -132,7 +132,7 @@ function jobdirname(job::BenchmarkJob)
 end
 
 reportdir(job::BenchmarkJob) = joinpath(reportdir(submission(job).config), "benchmark", jobdirname(job))
-tmpdir(job::BenchmarkJob) = joinpath(workdir(submission(job).config), "tmpresults")
+tmpdir(job::BenchmarkJob) = joinpath(workdir, "tmpresults")
 tmplogdir(job::BenchmarkJob) = joinpath(tmpdir(job), "logs")
 tmpdatadir(job::BenchmarkJob) = joinpath(tmpdir(job), "data")
 
@@ -313,7 +313,7 @@ function execute_benchmarks!(job::BenchmarkJob, juliapath, whichbuild::Symbol)
     node = myid()
     cfg = submission(job).config
     build = whichbuild == :against ? job.against : submission(job).build
-    builddir = mktempdir(workdir(cfg))
+    builddir = mktempdir(workdir)
     gid = parse(Int, readchomp(`id -g $(cfg.user)`))
     chmod(builddir, 0o755) # make it r-x to other than owner
 

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -189,7 +189,7 @@ function jobdirname(job::PkgEvalJob; latest::Bool=false)
 end
 
 reportdir(job::PkgEvalJob; kwargs...) = joinpath(reportdir(submission(job).config), "pkgeval", jobdirname(job; kwargs...))
-tmpdir(job::PkgEvalJob) = joinpath(workdir(submission(job).config), "tmpresults")
+tmpdir(job::PkgEvalJob) = joinpath(workdir, "tmpresults")
 tmplogdir(job::PkgEvalJob) = joinpath(tmpdir(job), "logs")
 tmpdatadir(job::PkgEvalJob) = joinpath(tmpdir(job), "data")
 

--- a/src/server.jl
+++ b/src/server.jl
@@ -50,7 +50,10 @@ end
 
 function Base.run(server::Server, args...; kwargs...)
     @assert myid() == 1 "Nanosoldier server must be run from the master node"
-    persistdir!(workdir(server.config))
+
+    nodelog(server.config, 1, "starting Nanosoldier server (working directory: $workdir)")
+    persistdir!(workdir)
+
     # Schedule a task for each node that feeds the node a job from the
     # queque once the node has completed its primary job. If the queue is
     # empty, then the task will call `yield` in order to avoid a deadlock.

--- a/src/submission.jl
+++ b/src/submission.jl
@@ -104,6 +104,11 @@ function parse_submission_string(submission_string)
 end
 
 function reply_status(sub::JobSubmission, context, state, description, url=nothing)
+    if haskey(ENV, "NANOSOLDIER_DRYRUN")
+        @info "Running as part of test suite, not uploading status" state description url
+        return ""
+    end
+
     if state == "failure"
         new_state = "success"
     else
@@ -118,6 +123,11 @@ function reply_status(sub::JobSubmission, context, state, description, url=nothi
 end
 
 function reply_comment(sub::JobSubmission, message::AbstractString)
+    if haskey(ENV, "NANOSOLDIER_DRYRUN")
+        @info "Running as part of test suite, not replying comment" message
+        return
+    end
+
     commentplace = sub.prnumber === nothing ? sub.statussha : sub.prnumber
     commentkind = sub.fromkind == :review ? :pr : sub.fromkind
     return GitHub.create_comment(sub.config.trackrepo, commentplace, commentkind;
@@ -125,6 +135,11 @@ function reply_comment(sub::JobSubmission, message::AbstractString)
 end
 
 function upload_report_repo!(sub::JobSubmission, markdownpath, message)
+    if haskey(ENV, "NANOSOLDIER_DRYRUN")
+        @info "Running as part of test suite, not uploading report" message
+        return ""
+    end
+
     cfg = sub.config
     dir = reportdir(cfg)
     run(setenv(`git add -A`; dir))

--- a/test/report.md
+++ b/test/report.md
@@ -2,9 +2,9 @@
 
 ## Job Properties
 
-*Commits:* [JuliaLang/julia@PRIMARY](https://github.com/JuliaLang/julia/commit/PRIMARY) vs [JuliaLang/julia@bb73f3489d837e3339fce2c1aab283d3b2e97a4c](https://github.com/JuliaLang/julia/commit/bb73f3489d837e3339fce2c1aab283d3b2e97a4c)
+*Commits:* [JuliaLang/julia@PRIMARY](https://github.com/JuliaLang/julia/commit/PRIMARY) vs [JuliaLang/julia@AGAINST](https://github.com/JuliaLang/julia/commit/AGAINST)
 
-*Comparison Diff:* [link](https://github.com/JuliaLang/julia/compare/bb73f3489d837e3339fce2c1aab283d3b2e97a4c..PRIMARY)
+*Comparison Diff:* [link](https://github.com/JuliaLang/julia/compare/AGAINST..PRIMARY)
 
 *Triggered By:* [link](https://www.test.com)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,9 +36,10 @@ auth = if haskey(ENV, "GITHUB_AUTH")
 else
     GitHub.AnonymousAuth()
 end
-latest_commit = GitHub.commits("JuliaLang/julia"; auth, page_limit=1)[1][1].sha
-primary = BuildRef("JuliaLang/julia", latest_commit, vinfo)
-against = BuildRef("JuliaLang/julia", "bb73f3489d837e3339fce2c1aab283d3b2e97a4c", vinfo*"_against")
+primary_commit = GitHub.commits("JuliaLang/julia"; auth, page_limit=1)[1][10].sha
+against_commit = GitHub.commits("JuliaLang/julia"; auth, page_limit=1)[1][11].sha
+primary = BuildRef("JuliaLang/julia", primary_commit, vinfo)
+against = BuildRef("JuliaLang/julia", against_commit, vinfo*"_against")
 config = Config("user", Dict(Any => [getpid()]), auth, "test", trackrepo=primary.repo);
 tagpred = "ALL && !(\"tag1\" || \"tag2\")"
 pkgsel = "[\"Example\"]"
@@ -185,7 +186,7 @@ results["judged"] = BenchmarkTools.judge(results["primary"], results["against"])
 
 @test begin
     mdpath = joinpath(@__DIR__, "report.md")
-    md = replace(read(mdpath, String), "PRIMARY" => latest_commit)
+    md = replace(read(mdpath, String), "PRIMARY" => primary_commit, "AGAINST" => against_commit)
     md2 = sprint(io->Nanosoldier.printreport(io, job, results))
     chomp.(eachline(IOBuffer(md))) == chomp.(eachline(IOBuffer(md2)))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -166,7 +166,7 @@ job = Nanosoldier.retrieve_job!(queue, Any, false)
 
 job = build_test_submission(BenchmarkJob, "@nanosoldier `runbenchmarks($tagpred)`")
 @test job.tagpred == tagpred
-@test job.against == nothing
+@test job.against === nothing
 job.against = against
 
 results = Dict(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,8 @@ using DataFrames
 # setup #
 #########
 
+ENV["NANOSOLDIER_DRYRUN"] = true
+
 vinfo = """
 Julia Version 0.4.3-pre+6
 Commit adffe19 (2015-12-11 00:38 UTC)
@@ -241,9 +243,14 @@ end
         )
 
     report = sprint(io -> Nanosoldier.printreport(io, job, results))
-
-    # XXX: actually test contents?
 end
 
+
+##################
+# actual testing #
+##################
+
+job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel, vs=\"@$against_commit\")`")
+run(job)
 
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -97,6 +97,15 @@ job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel, compile
 job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel, compiled=:both)`")
 @test job.compiled == :both
 
+job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel)`")
+@test job.rr == :primary
+job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel, rr=:primary)`")
+@test job.rr == :primary
+job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel, rr=:against)`")
+@test job.rr == :against
+job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel, rr=:both)`")
+@test job.rr == :both
+
 #############################
 # retrieval from job queue  #
 #############################
@@ -204,13 +213,12 @@ end
 
 @testset "PkgEvalJob" begin
     job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel)`")
-    @test job.against == nothing
+    @test job.against === nothing
 
     results = Dict{String,Any}(
         "primary" => DataFrame(
-            julia=v"1.6",
-            name="Example",
-            uuid=Base.UUID("12345678-1234-1234-1234-123456789abc"),
+            configuration="primary",
+            package="Example",
             version=v"0.1.0",
             status=:ok,
             reason=missing,
@@ -223,9 +231,8 @@ end
 
     job.against = against
     results["against"] = DataFrame(
-            julia=v"1.7",
-            name="Example",
-            uuid=Base.UUID("12345678-1234-1234-1234-123456789abc"),
+            configuration="against",
+            package="Example",
             version=v"0.1.0",
             status=:fail,
             reason=:test_failures,


### PR DESCRIPTION
I did some work on PkgEval, https://github.com/JuliaCI/PkgEval.jl/pull/105, so Nanosolder needed updating.

@vtjnash FYI, there's some changes in here that would affect the benchmark bot too:

- packages have been updated
- the workdir is now set-up using Scratch.jl
- comments/repo operations are skipped when `haskey(ENV, NANOSOLDIER_DRYRUN)`, so this could be used to actually run a BenchmarkJob during Nanosoldier CI