### PR TITLE
Don't log/comment errors, require an admin to look at the logs.

### DIFF
--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -216,11 +216,14 @@ function execute_tests!(job::PkgEvalJob, builds::Dict,
                 try
                     # NOTE: the merge head only exists in the upstream Julia repository,
                     #       and not in the repository where the pull request originated.
+                    # TODO: do this without reaching into PkgEval internals
+                    install = PkgEval.get_julia_repo("pull/$pr/merge")
                     julia = "pull/$pr/merge"
                     nodelog(cfg, node, "Resolved $whichbuild build to Julia merge head of PR $pr")
+                    rm(install; recursive=true)
                 catch err
-                    isa(err, LibGit2.GitError) || rethrow()
                     # there might not be a merge commit (e.g. in the case of merge conflicts)
+                    nodelog(cfg, node, "Could not check-out merge head of PR $pr"; error=err)
                 end
             end
         end


### PR DESCRIPTION
We recently leaked our environment-specified tokens in the log by dumping a Process object, so this PR includes a commit that removes all error reporting from the log generation. Instead, we'll now just comment that the job has failed, and expect the admin to check the server logs. cc @vtjnash