### PR TITLE
Make the PkgEval configuration generic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,35 +156,27 @@ The package selection argument is used to decide which packages to test. It shou
 
 The `vs` keyword argument is optional, and is used to determine whether or not the comparison step (step 3 above) is performed. Its syntax is identical to the `BenchmarkJob` `vs` keyword argument.
 
-Several other optional arguments are supported by this job:
-- `buildflags = ["...", ...]`: a list of flags that will be put in the `Make.user` for the primary build.
+Both sides of the comparison can be further configured by using respectively the `configuration` and `vs_configuration` arguments. These options expect a named tuple where the elements correspond to fields of the `PkgEval.Configuration` type.
 
-  This option can be used to, e.g., find packages that fail with assertions enabled:
-  ```
-  @nanosoldier `runtests(ALL, vs = "%self", buildflags=["LLVM_ASSERTIONS=1", "FORCE_ASSERTIONS=1"])`
-  ```
-- `vs_buildflags`: the same, but for the comparison build (defaults to no options, even if `buildflags` is set)
-- `compiled`: whether to run PkgEval in so-called compiled mode, where PackageCompiler.jl will be used to generate a custom system image before testing with it on a slightly different system. The value needs to be one of the following symbols:
-  - `:primary`: to compile tests for the primary build
-  - `:against`: to compile tests for the comparison build specified in the `vs` argument
-  - `:both`: to compile tests for both builds
-  - `:none` (default): do not use PackageCompiler.jl
-  
-  This option can be used to assess compileability of the ecosystem:
-  ```
-  @nanosoldier `runtests(ALL, vs = "%self", compiled = :primary)`
-  ```
+For example, a common configuration is to include buildflags that enable assertions:
 
-#### Benchmark Results
+```
+@nanosoldier `runtests(ALL, vs = "%self", configuration = (buildflags=["LLVM_ASSERTIONS=1", "FORCE_ASSERTIONS=1"],))`
+```
+
+If no configuration arguments are specified, the primary build will use `rr=true`, but other than that the defaults as specified by the `PkgEval.Configuration` constructor are used.
+
+#### Results
 
 Once a `PkgEvalJob` is complete, the results are uploaded to the
 [NanosoldierReports](https://github.com/JuliaCI/NanosoldierReports) repository. Each job
 has its own directory for results. This directory contains the following items:
 
 - `report.md` is a markdown report that summarizes the job results
-- `data.tar.gz` contains raw test data as Feather files encoding a DataFrame. To untar this file, run
-`tar -xzvf data.tar.gz`.
-- `logs` is a directory containing the test logs for the job.
+- `data.tar.xz` contains raw test data as Feather files encoding a DataFrame. To untar this file, run
+`tar -xvf data.tar.xz`.
+
+In addition, a rendered version of the report as well as the logs for each package are uploaded to AWS, and will be posted as a reply on GitHub where the job was invoked.
 
 ## Initial Setup for BenchmarksJob
 

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -229,7 +229,7 @@ function execute_tests!(job::PkgEvalJob, builds::Dict, base_configs::Dict, resul
     # determine packages to test
     pkgsel = Meta.parse(job.pkgsel)
     pkgs = if pkgsel == :ALL
-        PkgEval.registry_packages()
+        nothing
     else
         # safe to evaluate, it's a :vec of Strings
         [Package(; name) for name in eval(pkgsel)]
@@ -238,7 +238,11 @@ function execute_tests!(job::PkgEvalJob, builds::Dict, base_configs::Dict, resul
     # run tests
     all_tests = withenv("CI" => true) do
         cpus = mycpus(submission(job).config)
-        PkgEval.evaluate(configs, pkgs; ninstances=length(cpus))
+        if pkgs !== nothing
+            PkgEval.evaluate(configs, pkgs; ninstances=length(cpus))
+        else
+            PkgEval.evaluate(configs; ninstances=length(cpus))
+        end
     end
 
     # process the results for each Julia version separately

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -205,30 +205,8 @@ function execute_tests!(job::PkgEvalJob, builds::Dict, base_configs::Dict, resul
     configs = Dict{String,Configuration}()
     for (whichbuild, build) in builds
         # determine Julia version matching requested BuildRef
-        julia = nothing
-        if whichbuild == "primary" && submission(job).fromkind == :pr
-            # if we're dealing with a PR, try the merge commit
-            pr = submission(job).prnumber
-            if pr !== nothing
-                try
-                    # NOTE: the merge head only exists in the upstream Julia repository,
-                    #       and not in the repository where the pull request originated.
-                    # TODO: do this without reaching into PkgEval internals
-                    install = PkgEval.get_julia_repo("pull/$pr/merge")
-                    julia = "pull/$pr/merge"
-                    nodelog(cfg, node, "Resolved $whichbuild build to Julia merge head of PR $pr")
-                    rm(install; recursive=true)
-                catch err
-                    # there might not be a merge commit (e.g. in the case of merge conflicts)
-                    nodelog(cfg, node, "Could not check-out merge head of PR $pr";
-                            error=(err, catch_backtrace()))
-                end
-            end
-        end
-        if julia === nothing
-            julia = "$(build.repo)#$(build.sha)"
-            nodelog(cfg, node, "Resolved $whichbuild build to Julia commit $(build.sha) at $(build.repo)")
-        end
+        julia = "$(build.repo)#$(build.sha)"
+        nodelog(cfg, node, "Resolved $whichbuild build to Julia commit $(build.sha) at $(build.repo)")
 
         # create a configuration
         configs[whichbuild] = Configuration(base_configs[whichbuild]; julia)

--- a/src/server.jl
+++ b/src/server.jl
@@ -11,7 +11,7 @@ struct Server
         # job then gets added to the `jobs` queue, which is monitored and resolved by
         # the job-feeding tasks scheduled when `run` is called on the Server.
         handle = (event, phrase) -> begin
-            nodelog(config, 1, "received job submission with phrase $phrase")
+            nodelog(config, 1, "considering job submission with phrase $phrase")
             if event.kind == "issue_comment" && !haskey(event.payload["issue"], "pull_request")
                 return HTTP.Response(400, "nanosoldier jobs cannot be triggered from issue comments (only PRs or commits)")
             end
@@ -25,7 +25,8 @@ struct Server
                     try
                         job = J(submission)
                         push!(jobs, job)
-                        reply_status(job, "pending", "job added to queue: $(summary(job))")
+                        reply_status(job, "pending", "accepted $J: $(summary(job))")
+                        nodelog(config, 1, "job added to queue: $(summary(job))")
                         addedjob = true
                     catch err
                         nodelog(config, 1, "failed to constuct $J with a supposedly valid submission: $err",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,22 +91,11 @@ build_test_submission(PkgEvalJob, "@nanosoldier `runtests(\"pkg\")`")
 build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel)`")
 
 job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel)`")
-@test job.compiled == :none
-job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel, compiled=:primary)`")
-@test job.compiled == :primary
-job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel, compiled=:against)`")
-@test job.compiled == :against
-job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel, compiled=:both)`")
-@test job.compiled == :both
-
-job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel)`")
-@test job.rr == :primary
-job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel, rr=:primary)`")
-@test job.rr == :primary
-job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel, rr=:against)`")
-@test job.rr == :against
-job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel, rr=:both)`")
-@test job.rr == :both
+@test !job.configuration.compiled
+job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel, configuration=(compiled=true, ))`")
+@test job.configuration.compiled
+job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel, configuration=(buildflags=[\"FOO=BAR\"], ))`")
+@test job.configuration.buildflags == ["FOO=BAR"]
 
 #############################
 # retrieval from job queue  #


### PR DESCRIPTION
Instead of having to add support for every new PkgEval feature, just construct a tuple and forward it to PkgEval's `Configuration` constructor.