### PR TITLE
Introduce a sudo helper, and other Git.jl-related fixes

### DIFF
--- a/src/Nanosoldier.jl
+++ b/src/Nanosoldier.jl
@@ -42,12 +42,12 @@ function gitclone!(repo, dir, auth=nothing, args::Cmd=``; user=nothing)
     end
     if user === nothing
         if auth !== nothing
-            run(`mkdir -m 770 $dir`)
+            run(`mkdir -p -m 770 $dir`)
         end
         run(`$(git()) clone $args $url$repo.git $dir`)
     else
         if auth !== nothing
-            run(sudo(`-n -u $user`, `mkdir -m 770 $dir`))
+            run(sudo(`-n -u $user`, `mkdir -p -m 770 $dir`))
         end
         run(sudo(`-n -u $user`, `$(git()) clone $args $url$repo.git $dir`))
     end

--- a/src/Nanosoldier.jl
+++ b/src/Nanosoldier.jl
@@ -20,6 +20,17 @@ workdir = ""
 snip(str, len) = str[1:min(len, end)]
 snipsha(sha) = snip(sha, 7)
 
+sudo(cmd::Cmd) = sudo(`-n`, cmd)
+sudo(user::String, cmd::Cmd) = sudo(`-n -u $user`, cmd)
+function sudo(args::Cmd, cmd::Cmd)
+    # non-default environment behavior is only permitted for the first interpolant,
+    # so we need to splice the command's environment into the sudo invocation.
+    dir = cmd.dir
+    env = something(cmd.env, [])
+    cmd = Cmd(cmd; env=nothing, dir="")
+    setenv(`sudo $args $env -- $cmd`; dir)
+end
+
 function gitclone!(repo, dir, auth=nothing, args::Cmd=``; user=nothing)
     if isa(auth, GitHub.OAuth2)
         url = "https://$(auth.token):x-oauth-basic@github.com/"
@@ -29,11 +40,17 @@ function gitclone!(repo, dir, auth=nothing, args::Cmd=``; user=nothing)
         auth = auth::Nothing
         url = "https://github.com/"
     end
-    sudo = user === nothing ? `` : `sudo -n -u $user --`
-    if auth !== nothing
-        run(setenv(`$sudo mkdir -m 770 $dir`)) # hide auth from everybody
+    if user === nothing
+        if auth !== nothing
+            run(`mkdir -m 770 $dir`)
+        end
+        run(`$(git()) clone $args $url$repo.git $dir`)
+    else
+        if auth !== nothing
+            run(sudo(`-n -u $user`, `mkdir -m 770 $dir`))
+        end
+        run(sudo(`-n -u $user`, `$(git()) clone $args $url$repo.git $dir`))
     end
-    run(setenv(`$sudo $(git()) clone $args $url$repo.git $dir`))
 end
 gitclone!(repo, dir, args::Cmd; user=nothing) = gitclone!(repo, dir, nothing, args; user)
 

--- a/src/build.jl
+++ b/src/build.jl
@@ -55,7 +55,7 @@ function build_julia!(config::Config, build::BuildRef, logpath, prnumber::Union{
     mirrordir = joinpath(workdir, "mirrors", split(config.trackrepo, "/")...)
     mkpath(dirname(mirrordir), mode=0o755)
     mkpidlock(mirrordir * ".lock") do
-        if ispath(mirrordir)
+        if ispath(mirrordir, ".git")
             run(`$(git()) -C $mirrordir fetch --quiet --all`)
         else
             mkpath(mirrordir)

--- a/src/config.jl
+++ b/src/config.jl
@@ -35,7 +35,7 @@ persistdir!(path) = (isdir(path) || mkdir(path); return path)
 
 function persistdir!(config::Config)
     persistdir!(workdir)
-    if isdir(reportdir(config))
+    if isdir(joinpath(reportdir(config), ".git"))
         gitreset!(reportdir(config))
     else
         gitclone!(reportrepo(config), reportdir(config), config.auth)

--- a/src/submission.jl
+++ b/src/submission.jl
@@ -150,6 +150,7 @@ function upload_report_repo!(sub::JobSubmission, markdownpath, message)
     sha = readchomp(`$(git()) -C $dir rev-parse HEAD`)
 
     # cherry-pick on top of latest master
+    run(`$(git()) -C $dir checkout master`)
     gitreset!(dir)
     run(`$(git()) -C $dir cherry-pick -X ours $sha`)
 

--- a/src/submission.jl
+++ b/src/submission.jl
@@ -144,7 +144,7 @@ function upload_report_repo!(sub::JobSubmission, markdownpath, message)
     dir = reportdir(cfg)
 
     # create a detached commit
-    run(`$(git()) -c $dir checkout --detach`)
+    run(`$(git()) -C $dir checkout --detach`)
     run(`$(git()) -C $dir add -A`)
     run(`$(git()) -C $dir commit -m $message`)
     sha = readchomp(`$(git()) -C $dir rev-parse HEAD`)


### PR DESCRIPTION
Turns out there was a problem with https://github.com/JuliaCI/Nanosoldier.jl/pull/122: Git.jl's `git()` is a Cmd object with environment (aka `setenv`) and those are only allowed as the first Cmd object in an interpolation, breaking `sudo -- $(git())`. So instead, I added a `sudo` helper method here that copies the dir/env to the toplevel env (actually passing the env vars on the command line, as expected by `sudo`).