### PR TITLE
Derive the daily date from the commit timestamp.

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -3,18 +3,20 @@
 ############
 
 mutable struct BuildRef
-    repo::String  # the build repo
-    sha::String   # the build + status SHA
-    vinfo::String # versioninfo() taken during the build
+    repo::String    # the build repo
+    sha::String     # the build + status SHA
+    time::DateTime  # a timestamp for the build
+    vinfo::String   # versioninfo() taken during the build
 end
 
-BuildRef(repo, sha) = BuildRef(repo, sha, "retrieving versioninfo() failed")
+BuildRef(repo, sha, time) = BuildRef(repo, sha, time, "retrieving versioninfo() failed")
 
-Base.copy(x::BuildRef) = BuildRef(x.repo, x.sha, x.vinfo)
+Base.copy(x::BuildRef) = BuildRef(x.repo, x.sha, x.time, x.vinfo)
 
 function Base.:(==)(a::BuildRef, b::BuildRef)
     return (a.repo == b.repo &&
             a.sha == b.sha &&
+            a.time == b.time &&
             a.vinfo == b.vinfo)
 end
 
@@ -76,6 +78,7 @@ function build_julia!(config::Config, build::BuildRef, logpath, prnumber::Union{
         end
         run(sudo(config.user, `$(git()) -C $srcdir checkout --quiet --force FETCH_HEAD`))
         build.sha = readchomp(sudo(config.user, `$(git()) -C $srcdir rev-parse HEAD`))
+        # XXX: update build.time here?
     else
         gitclone!(build.repo, srcdir, `-c core.sharedRepository=group --reference $mirrordir --dissociate`; user=config.user)
         run(sudo(config.user, `$(git()) -C $srcdir checkout --quiet $(build.sha)`))

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -55,7 +55,7 @@ function BenchmarkJob(submission::JobSubmission)
         if in(SHA_SEPARATOR, againststr) # e.g. againststr == christopher-dG/julia@e83b7559df94b3050603847dbd6f3674058027e6
             reporef, againstsha = split(againststr, SHA_SEPARATOR)
             againstrepo = isempty(reporef) ? submission.config.trackrepo : reporef
-            againstbuild = BuildRef(againstrepo, againstsha)
+            againstbuild = commitref(submission.config, againstrepo, againstsha)
         elseif in(BRANCH_SEPARATOR, againststr)
             reporef, againstbranch = split(againststr, BRANCH_SEPARATOR)
             againstrepo = isempty(reporef) ? submission.config.trackrepo : reporef
@@ -88,7 +88,7 @@ function BenchmarkJob(submission::JobSubmission)
     end
 
     return BenchmarkJob(submission, first(submission.args), against,
-                        Dates.today(), isdaily, skipbuild)
+                        Date(submission.build.time), isdaily, skipbuild)
 end
 
 function Base.summary(job::BenchmarkJob)

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -95,7 +95,7 @@ function PkgEvalJob(submission::JobSubmission)
         if in(SHA_SEPARATOR, againststr) # e.g. againststr == christopher-dG/julia@e83b7559df94b3050603847dbd6f3674058027e6
             reporef, againstsha = split(againststr, SHA_SEPARATOR)
             againstrepo = isempty(reporef) ? submission.config.trackrepo : reporef
-            againstbuild = BuildRef(againstrepo, againstsha)
+            againstbuild = commitref(submission.config, againstrepo, againstsha)
         elseif in(BRANCH_SEPARATOR, againststr)
             reporef, againstbranch = split(againststr, BRANCH_SEPARATOR)
             againstrepo = isempty(reporef) ? submission.config.trackrepo : reporef
@@ -144,7 +144,8 @@ function PkgEvalJob(submission::JobSubmission)
     end
 
     return PkgEvalJob(submission, first(submission.args), against,
-                      Dates.today(), isdaily, configuration, against_configuration)
+                      Date(submission.build.time), isdaily,
+                      configuration, against_configuration)
 end
 
 function Base.summary(job::PkgEvalJob)

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -585,7 +585,7 @@ function printreport(io::IO, job::PkgEvalJob, results)
             latest_dir = reportdir(job; latest=true)
             against_date = Date(job.against.time)
             if isdir(latest_dir) && islink(latest_dir)
-                prev_reportlink = "../../$(readlink(latest_dir))/report.md"
+                prev_reportlink = "../../$(readlink(latest_dir))/report.html"
                 against_date = "[$(against_date)]($(prev_reportlink))"
             end
             dailystr = string(job.date, " vs ", against_date)

--- a/src/jobs/jobs.jl
+++ b/src/jobs/jobs.jl
@@ -12,14 +12,19 @@ reply_status(job::AbstractJob, args...; kwargs...) = reply_status(submission(job
 reply_comment(job::AbstractJob, args...; kwargs...) = reply_comment(submission(job), args...; kwargs...)
 upload_report_repo!(job::AbstractJob, args...; kwargs...) = upload_report_repo!(submission(job), args...; kwargs...)
 
+function commitref(config::Config, reponame::AbstractString, shastr::AbstractString)
+    commit = GitHub.commit(reponame, shastr; auth=config.auth)
+    return BuildRef(reponame, shastr, commit.commit.committer.date)
+end
+
 function branchref(config::Config, reponame::AbstractString, branchname::AbstractString)
-    shastr = GitHub.branch(reponame, branchname; auth=config.auth).commit.sha
-    return BuildRef(reponame, shastr)
+    commit = GitHub.branch(reponame, branchname; auth=config.auth).commit
+    return BuildRef(reponame, commit.sha, commit.commit.committer.date)
 end
 
 function tagref(config::Config, reponame::AbstractString, tagname::AbstractString)
-    shastr = GitHub.tag(reponame, tagname; auth=config.auth).object["sha"]
-    return BuildRef(reponame, shastr)
+    tag = GitHub.tag(reponame, tagname; auth=config.auth)
+    commitref(config, reponame, tag.object["sha"])
 end
 
 # check that isdaily is well-formed (no extra parameters, on a recent master commit, not a PR)

--- a/src/submission.jl
+++ b/src/submission.jl
@@ -72,7 +72,12 @@ function parse_event(config::Config, event::GitHub.WebhookEvent)
         fromkind = :pr
         prnumber = Int(pr.number)
     end
-    return BuildRef(repo, sha), sha, url, fromkind, prnumber
+
+    # look up the date of the commit (this is not part of the event)
+    commit = GitHub.commit(repo, sha, auth=config.auth)
+    time = commit.commit.committer.date
+
+    return BuildRef(repo, sha, time), sha, url, fromkind, prnumber
 end
 
 # `x` can only be Expr, Symbol, QuoteNode, T<:Number, or T<:AbstractString


### PR DESCRIPTION
Currently, it's not possible to retry a daily evaluation after the day has passed, because the date of the daily is determined by looking at `Dates.today()`. That's annoying, especially now that were keeping stats and visualizing them we might want to retry a failed or suspicious evaluation.

This PR makes it so that the date of the daily is derived from the commit timestamp of the commit it was requested on.