### PR TITLE
PkgEval: go back to hiding crashes that failed everywhere

### DIFF
--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -731,8 +731,9 @@ function printreport(io::IO, job::PkgEvalJob, results)
                 end
             end
 
-            if hasagainstbuild && status !== :crash
-                # first report on tests that changed status
+            if hasagainstbuild && !(job.isdaily && status === :crash)
+                # first report on tests that changed status. note that we don't do this for
+                # crashes on daily tests, to feature them more prominently in the report.
                 changed_tests = filter(test->test.source == "both" &&
                                              test.status != test.status_1, group)
                 if !isempty(changed_tests)


### PR DESCRIPTION
I recently started showing crashes always (i.e. not in a collapsed section when the comparison build also crashed), but that may be too opinionated, at least for non-daily evaluation. For example, in https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/f1ae425_vs_317211a/report.html it makes it less clear which crashes were introduced.