### PR TITLE
Improve legibility of Nanosoldier's comments

### DIFF
--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -554,8 +554,8 @@ function report(job::BenchmarkJob, results)
 
         # reply with the job's final status
         comment = """
-            [Your benchmark job]($(submission(job).url)) has completed - $status.
-            A full report can be found [here]($(target_url))."""
+            The benchmark job [you requested]($(submission(job).url)) has completed - $status.
+            The [**full report**]($(target_url)) is available."""
         reply_comment(submission(job), comment)
     end
 end

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -813,8 +813,8 @@ function report(job::PkgEvalJob, results)
 
         # reply with the job's final status
         comment = """
-            [Your package evaluation job]($(submission(job).url)) has completed - $status.
-            A full report can be found [here]($(target_url))."""
+            The package evaluation job [you requested]($(submission(job).url)) has completed - $status.
+            The [**full report**]($(target_url)) is available."""
         reply_comment(submission(job), comment)
     end
 end


### PR DESCRIPTION
As a frequent lurker in the JuliaLang/julia PRs, I've often found myself clicking the wrong link in the Nanosoldier comments. I realize that experienced contributors are likely used to the current format and aren't affected by its slighly ambiguous phrasing, but new contributors might trip the first time or two.

This is essentially a small QOL improvement that hopefully saves fractions of a second each time someone has to read and mentally parse the Nanosoldier comments, which might add up to a non-negligible amount over time and across a large enough community :) Specifically, the following changes are made:

- The submission link refers to the request, not to the job; therefore, the sentence is reworded to make this clear.
- The tarket link is the most important; therefore, the actual link is moved to the "full report" expression and the link text is emphasised so it stands out in Nanosoldier's comment.
