### PR TITLE
Upload pkgeval reports generated in testing as github artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+          - uses: actions/upload-artifact@v3
+            with:
+              name: uploads-to-NanosoldierReports
+              path: /home/runner/.julia/scratchspaces/89f34f1a-2e6b-52eb-a20f-77051b03b735/workdir/NanosoldierReports/pkgeval/by_hash/redacted_vs_redacted/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
-          - uses: actions/upload-artifact@v3
-            with:
-              name: uploads-to-NanosoldierReports
-              path: /home/runner/.julia/scratchspaces/89f34f1a-2e6b-52eb-a20f-77051b03b735/workdir/NanosoldierReports/pkgeval/by_hash/redacted_vs_redacted/
+      - uses: actions/upload-artifact@v3
+        with:
+          name: uploads-to-NanosoldierReports
+          path: /home/runner/.julia/scratchspaces/89f34f1a-2e6b-52eb-a20f-77051b03b735/workdir/NanosoldierReports/pkgeval/by_hash/redacted_vs_redacted/

--- a/src/jobs/jobs.jl
+++ b/src/jobs/jobs.jl
@@ -58,7 +58,14 @@ end
 function upload_report_repo!(job::AbstractJob, markdownpath, message)
     if haskey(ENV, "NANOSOLDIER_DRYRUN")
         @info "Running as part of test suite, not uploading report" message
-        return "nonexistent"
+
+        # copy the report to a path that does not depend on the commit hash to makes it
+        # easier to locate and upload as a test artifact.
+        source = reportdir(job)
+        target = joinpath(dirname(source), "redacted_vs_redacted")
+        cp(source, target)
+
+        return tempdir(target)
     end
 
     cfg = submission(job).config

--- a/src/jobs/jobs.jl
+++ b/src/jobs/jobs.jl
@@ -65,7 +65,7 @@ function upload_report_repo!(job::AbstractJob, markdownpath, message)
         target = joinpath(dirname(source), "redacted_vs_redacted")
         cp(source, target)
 
-        return tempdir(target)
+        return target
     end
 
     cfg = submission(job).config


### PR DESCRIPTION
>> Is it possible to view the markdown summary generated in CI?
>
> It's currently not published anywhere, no.

_originally posted by @maleadt in https://github.com/JuliaCI/Nanosoldier.jl/pull/170#issuecomment-1660144744_

This makes it possible to verify that changes to the markdown of uploaded reports are well formed in CI, a useful feature for reviewing/testing https://github.com/JuliaCI/Nanosoldier.jl/pull/170