### PR TITLE
Report version as "missing" if it is missing instead of omitting it for alignment.

### DIFF
--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -1087,11 +1087,13 @@ function printreport(io::IO, job::PkgEvalJob, results)
                 # "against" entries are suffixed with `_1` because of the join
                 if test.source == "both"
                     # PkgEval always compares the same package versions, so only report it once
-                    print(io, "| $(test.package) |")
+                    print(io, "| $(test.package) | ")
                     if test.version !== missing
                         print(io, "v$(test.version) | ")
-                    elseif test.source == "both" && test.version_1 !== missing
+                    elseif test.version_1 !== missing
                         print(io, "v$(test.version_1) | ")
+                    else
+                        print(io, "missing | ")
                     end
 
                     print(io, "[$primary_status]($primary_log) | ")


### PR DESCRIPTION
This should fix the alignment issue reported in https://github.com/JuliaCI/Nanosoldier.jl/issues/173 with markdown file available [here](https://github.com/JuliaCI/NanosoldierReports/blob/ba5eab7d81620955e88d65dd556e4cfda3f54238/pkgeval/by_date/2023-08/06/report.md#L2973)

Also, add a space for consistency and prettier markdown formatting.