### PR TITLE
Add color to the history plots in rendered HTML

### DIFF
--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -726,6 +726,10 @@ end
 # PkgEvalJob Reporting #
 ########################
 
+const COLOR_MAP = map(('▁' => "#60F", '▂' => "#F03", '▄' => "#FF0", '▅' => "#666", '▇' => "#0F0")) do (char, color)
+    Regex("($char+)") => SubstitutionString("<span style=\"color: $color\">\\1</span>")
+end
+
 # report job results back to GitHub
 function report(job::PkgEvalJob, results)
     node = myid()
@@ -789,6 +793,7 @@ function report(job::PkgEvalJob, results)
                     <body>$body</body>
                     </html>
                 """
+                report_html = replace(report_html, COLOR_MAP...)
                 try
                     S3.put_object("$(cfg.bucket)/pkgeval/$(jobdirname(job))",
                                   "report.html",


### PR DESCRIPTION
It should look like this

<img width="994" alt="Screenshot 2023-08-08 at 1 52 31 PM" src="https://github.com/JuliaCI/Nanosoldier.jl/assets/60898866/5634e870-ace7-42e7-ae06-786f9b8bea4b">

Though CI doesn't upload rendered HTML so it will be hard to review this PR.