### PR TITLE
Add legend for PkgEval history plots

### DIFF
--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -1061,6 +1061,10 @@ function printreport(io::IO, job::PkgEvalJob, results)
                                                 package_results))
     end
 
+    # Provide a legend to interpret history plots
+    legend_entries = (('▁' + Int(s)) * '=' * string(s) for s in instances(HistoricalStatus))
+    println(io, "History Legend: ", join(legend_entries, ", "), ".\n")
+
     # report test results in groups based on the test status
     history_heading, history = get_history(submission(job).config)
     dependents = package_dependents()


### PR DESCRIPTION
Should look like this

<img width="610" alt="Screenshot 2023-08-08 at 2 13 12 PM" src="https://github.com/JuliaCI/Nanosoldier.jl/assets/60898866/fd030cb3-b059-4025-937f-0012b2576bd2">

Should mesh okay with #175. The boxes will be colored but not the text that follows.