### PR TITLE
Save sizes of built dynamic libraries and sys images

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -193,7 +193,9 @@ results = Dict(
             )
         )
     ),
-    "against.vinfo" => vinfo*"_against"
+    "against.vinfo" => vinfo*"_against",
+    "primary.artifact_sizes" => Dict("libLLVM.so" => 123456, "sys.so" => 789012),
+    "against.artifact_sizes" => Dict("libLLVM.so" => 123456, "sys.so" => 789012),
 )
 
 results["judged"] = BenchmarkTools.judge(results["primary"], results["against"])


### PR DESCRIPTION
I just picked some big files that seemed related to Julia or LLVM. 
The results are not shown in the report currently, I don't expect these sizes to change much frequently so it didn't seem necessary. I plan on adding these to https://tealquaternion.camdvr.org/.
I've tried to make sure even if fetching/ saving the sizes fails it doesn't affect anything else.

I wasn't sure how to test this locally.