### PR TITLE
Add instruction / branch counts to BenchmarkJob reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7'
+          - '1.9'
         os:
           - ubuntu-latest
         arch:

--- a/test/report.md
+++ b/test/report.md
@@ -29,11 +29,11 @@ than `1.0` denotes a possible improvement (marked with :white_check_mark:). Only
 that indicate possible regressions or improvements - are shown below (thus, an empty table means that all
 benchmark results remained invariant between builds).
 
-| ID | time ratio | memory ratio |
-|----|------------|--------------|
-| `["g", "h", "z"]` | 1.00 (60%)  | 5.00 (27%) :x: |
-| `["g", "h", ("y", 1)]` | 2.00 (5%) :x: | 0.00 (3%) :white_check_mark: |
-| `["g", "h", ("y", 2)]` | 0.50 (5%) :white_check_mark: | 1.00 (1%)  |
+| ID | time ratio | instruction ratio | branch ratio | memory ratio |
+|----|------------|-------------------|--------------|--------------|
+| `["g", "h", "z"]` | 1.00 (60%)  | 1.00 (5%)  | 1.00 (5%)  | 5.00 (27%) :x: |
+| `["g", "h", ("y", 1)]` | 2.00 (5%) :x: | 2.00 (5%) :x: | 2.00 (5%) :x: | 0.00 (3%) :white_check_mark: |
+| `["g", "h", ("y", 2)]` | 0.50 (5%) :white_check_mark: | 0.50 (5%) :white_check_mark: | 0.50 (5%) :white_check_mark: | 1.00 (1%)  |
 
 ## Benchmark Group List
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -174,11 +174,11 @@ results = Dict(
     "primary" => BenchmarkGroup([],
         "g" => BenchmarkGroup([],
             "h" => BenchmarkGroup([],
-                "x"      => TrialEstimate(Parameters(), 1.0, 3.5, 1.0, 1.0),  # invariant
-                ("y", 1) => TrialEstimate(Parameters(memory_tolerance = 0.03), 2.0, 1.0, 0.0, 1.0),  # regression/improvement
-                ("y", 2) => TrialEstimate(Parameters(time_tolerance = 0.04), 0.5, 1.0, 1.0, 1.0),  # improvement
-                "z"      => TrialEstimate(Parameters(memory_tolerance = 0.27, time_tolerance = 0.6), 1.0, 1.0, 5.0, 1.0),  # regression
-                "∅"      => TrialEstimate(Parameters(), 1.0, 1.0, 1.0, 1.0) # not in "against" group
+                "x"      => TrialEstimate(Parameters(), 1.0, 1.0, 1.0, 3.5, 1, 1),  # invariant
+                ("y", 1) => TrialEstimate(Parameters(memory_tolerance = 0.03), 2.0, 2.0, 2.0, 1.0, 0, 1),  # regression/improvement
+                ("y", 2) => TrialEstimate(Parameters(time_tolerance = 0.04), 0.5, 0.5, 0.5, 1.0, 1, 1),  # improvement
+                "z"      => TrialEstimate(Parameters(memory_tolerance = 0.27, time_tolerance = 0.6), 1.0, 1.0, 1.0, 1.0, 5, 1),  # regression
+                "∅"      => TrialEstimate(Parameters(), 1.0, 1.0, 1.0, 1.0, 1, 1) # not in "against" group
             )
         )
     ),
@@ -186,10 +186,10 @@ results = Dict(
     "against" => BenchmarkGroup([],
         "g" => BenchmarkGroup([],
             "h" => BenchmarkGroup([],
-                "x"      => TrialEstimate(Parameters(), 1.0, 1.0, 1.0, 1.0),
-                ("y", 1) => TrialEstimate(Parameters(), 1.0, 1.0, 1.0, 1.0),
-                ("y", 2) => TrialEstimate(Parameters(), 1.0, 1.0, 1.0, 1.0),
-                "z"      => TrialEstimate(Parameters(), 1.0, 1.0, 1.0, 1.0)
+                "x"      => TrialEstimate(Parameters(), 1.0, 1.0, 1.0, 1.0, 1, 1),
+                ("y", 1) => TrialEstimate(Parameters(), 1.0, 1.0, 1.0, 1.0, 1, 1),
+                ("y", 2) => TrialEstimate(Parameters(), 1.0, 1.0, 1.0, 1.0, 1, 1),
+                "z"      => TrialEstimate(Parameters(), 1.0, 1.0, 1.0, 1.0, 1, 1)
             )
         )
     ),


### PR DESCRIPTION
A quick attempt to see what it would look like to integrate https://github.com/JuliaCI/BenchmarkTools.jl/pull/375, which provides branch / instruction counts based on LinuxPerf.jl

We might have to twiddle with `perf_event_paranoid` (assuming that we can) to get it to <= 2 so that the process is allowed to monitor itself. We'll also have to consider whether contention for the PMU resources is going to be a problem - IIUC these are per-thread in most cases though so this should likely be OK?