### PR TITLE
PkgEval: Disable the blacklist based on age.

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -20,7 +20,6 @@ function gitclone!(repo, dir, auth=nothing, args::Cmd=``; user=nothing)
     elseif isa(auth, GitHub.UsernamePassAuth)
         url = "https://$(auth.username):$(auth.password)@github.com/"
     else
-        auth = auth::Nothing
         url = "https://github.com/"
     end
     if user === nothing


### PR DESCRIPTION
Now that we use implicit merge bases, simply checking vs doesn't work.