### PR TITLE
Print headlines in bot report comment

### DIFF
--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -1163,6 +1163,7 @@ function printreport(io::IO, job::PkgEvalJob, results)
 end
 
 function printpackageresults(io::IO, job::PkgEvalJob, package_results, hasagainstbuild::Bool; headlines_only::Bool=false)
+    cfg = submission(job).config
     # report test results in groups based on the test status
     history_heading, history = get_history(submission(job).config)
     dependents = package_dependents()

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -858,7 +858,9 @@ function report(job::PkgEvalJob, results)
             The package evaluation job [you requested]($(submission(job).url)) has completed - $status.
             The [**full report**]($(target_url)) is available.
 
+            <details><summary>Report summary</summary>
             $report_summary
+            </details>
             """
         reply_comment(submission(job), comment)
     end

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -1233,12 +1233,11 @@ function printpackageresults(io::IO, job::PkgEvalJob, package_results; headlines
                 subgroups = groupby(group, :reason; skipmissing=true)
                 for key in sort(keys(subgroups); by=key->PkgEval.reason_severity(key.reason))
                     subgroup = subgroups[key]
-                    headline = "$(uppercasefirst(PkgEval.reason_message(first(subgroup).reason))) ($(nrow(subgroup)) packages):"
                     if headlines_only
-                        println(io, headline)
+                        println(io, " - $(nrow(subgroup)) : $(uppercasefirst(PkgEval.reason_message(first(subgroup).reason))) :")
                     else
                         println(io, """
-                            <details open><summary>$headline</summary>
+                            <details open><summary>"$(uppercasefirst(PkgEval.reason_message(first(subgroup).reason))) ($(nrow(subgroup)) packages):"</summary>
                             <p>
                             """)
                         println(io)

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -849,9 +849,9 @@ function report(job::PkgEvalJob, results)
             results["has_issues"] ? "possible issues were detected" :
                                     "no issues were detected"
         end
-
-        package_results = make_package_results(results, job.against !== nothing)
-        report_summary = sprint(io -> printpackageresults(io, job, package_results; headlines_only=true))
+        hasagainstbuild = job.against !== nothing
+        package_results = make_package_results(results, hasagainstbuild)
+        report_summary = sprint(io -> printpackageresults(io, job, package_results, hasagainstbuild; headlines_only=true))
 
         # reply with the job's final status
         comment = """
@@ -1123,7 +1123,7 @@ function printreport(io::IO, job::PkgEvalJob, results)
     end
 
     # main results body
-    printpackageresults(io, job, package_results)
+    printpackageresults(io, job, package_results, hasagainstbuild)
 
     # print build version info #
     #--------------------------#
@@ -1162,7 +1162,7 @@ function printreport(io::IO, job::PkgEvalJob, results)
     return nothing
 end
 
-function printpackageresults(io::IO, job::PkgEvalJob, package_results; headlines_only::Bool=false)
+function printpackageresults(io::IO, job::PkgEvalJob, package_results, hasagainstbuild::Bool; headlines_only::Bool=false)
     # report test results in groups based on the test status
     history_heading, history = get_history(submission(job).config)
     dependents = package_dependents()

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -967,7 +967,7 @@ end
 function make_package_results(results, hasagainstbuild)
     if hasagainstbuild
         return leftjoin(results["primary"], results["against"],
-                                   on=:package, makeunique=true, source=:source)
+                        on=:package, makeunique=true, source=:source)
     else
         package_results = results["primary"]
         package_results[!, :source] .= "left_only" # fake a left join
@@ -1123,7 +1123,7 @@ function printreport(io::IO, job::PkgEvalJob, results)
     # main results body
     printpackageresults(io, job, package_results)
 
-        # print build version info #
+    # print build version info #
     #--------------------------#
 
     print(io, """

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -857,7 +857,6 @@ function report(job::PkgEvalJob, results)
         comment = """
             The package evaluation job [you requested]($(submission(job).url)) has completed - $status.
             The [**full report**]($(target_url)) is available.
-
             <details><summary>Report summary</summary>
             $report_summary
             </details>


### PR DESCRIPTION
I think it would be helpful to give the headlines in the report comment from the bot.
I haven't run this, but the goal is to look something like the collapsed form of the report.

A more compressed version may be possible.

![Screenshot 2024-12-18 at 3 19 13 PM](https://github.com/user-attachments/assets/81146b8d-2642-4d30-8d9d-e648c3c96a6e)


