### PR TITLE
Add priority system for job queue management

### DIFF
--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -47,12 +47,13 @@ mutable struct BenchmarkJob <: AbstractJob
     date::Dates.Date                 # the date of the submitted job
     isdaily::Bool                    # is the job a daily job?
     skipbuild::Bool                  # use local julia install instead of a fresh build (for testing)
+    priority::Int                    # job priority: 1=high, 2=normal, 3=low
 end
 
 function BenchmarkJob(submission::JobSubmission)
     # preliminary validation
     for kwarg in keys(submission.kwargs)
-        if !in(kwarg, (:vs, :skipbuild, :isdaily))
+        if !in(kwarg, (:vs, :skipbuild, :isdaily, :priority))
             nanosoldier_error("invalid keyword argument `$kwarg`")
         end
     end
@@ -117,8 +118,11 @@ function BenchmarkJob(submission::JobSubmission)
         first(submission.args)
     end
 
-    return BenchmarkJob(submission, tagpred, against,
-                        Date(submission.build.time), isdaily, skipbuild)
+    return BenchmarkJob(
+        submission, tagpred, against,
+        Date(submission.build.time), isdaily, skipbuild,
+        Nanosoldier.priority(submission)
+    )
 end
 
 function Base.summary(job::BenchmarkJob)

--- a/src/jobs/PkgEvalJob.jl
+++ b/src/jobs/PkgEvalJob.jl
@@ -97,12 +97,13 @@ mutable struct PkgEvalJob <: AbstractJob
     against_configuration::Configuration
     use_blacklist::Bool
     subdir::String                   # which subdirectory to use (for package tests)
+    priority::Int                    # job priority: 1=high, 2=normal, 3=low
 end
 
 function PkgEvalJob(submission::JobSubmission)
     # preliminary validation
     for kwarg in keys(submission.kwargs)
-        if !in(kwarg, (:vs, :isdaily, :configuration, :vs_configuration, :subdir))
+        if !in(kwarg, (:vs, :isdaily, :configuration, :vs_configuration, :subdir, :priority))
             nanosoldier_error("invalid keyword argument `$kwarg`")
         end
     end
@@ -265,10 +266,12 @@ function PkgEvalJob(submission::JobSubmission)
         end
     end
 
-    return PkgEvalJob(submission, jobtype, pkgsel, against,
-                      Date(submission.build.time), isdaily,
-                      configuration, against_configuration,
-                      use_blacklist, subdir)
+    return PkgEvalJob(
+        submission, jobtype, pkgsel, against,
+        Date(submission.build.time), isdaily,
+        configuration, against_configuration,
+        use_blacklist, subdir, Nanosoldier.priority(submission)
+    )
 end
 
 function Base.summary(job::PkgEvalJob)

--- a/src/server.jl
+++ b/src/server.jl
@@ -109,12 +109,22 @@ function retrieve_job!(jobs, job_type::Type, accept_daily::Bool)
     if isempty(jobs)
         return nothing
     else
-        i = findfirst(job -> isa(job, job_type) && (accept_daily || !job.isdaily), jobs)
-        if i === nothing
+        # Find all matching jobs
+        matching_indices = findall(job -> isa(job, job_type) && (accept_daily || !job.isdaily), jobs)
+        if isempty(matching_indices)
             return nothing
         else
-            job = jobs[i]
-            deleteat!(jobs, i)
+            # Find the highest priority job (lowest priority number)
+            best_idx = matching_indices[1]
+            best_priority = jobs[best_idx].priority
+            for idx in matching_indices[2:end]
+                if jobs[idx].priority < best_priority
+                    best_idx = idx
+                    best_priority = jobs[idx].priority
+                end
+            end
+            job = jobs[best_idx]
+            deleteat!(jobs, best_idx)
             return job
         end
     end

--- a/src/submission.jl
+++ b/src/submission.jl
@@ -117,8 +117,24 @@ function parse_submission_string(submission_string)
         process_arg(parsed_args)
     end
 
+    if haskey(kwargs, :priority)
+        priority_str = strip(kwargs[:priority], '"')  # Remove quotes added by phrase_argument
+        if priority_str == "high"
+            kwargs[:priority] = "1"
+        elseif priority_str == "normal"
+            kwargs[:priority] = "2"
+        elseif priority_str == "low"
+            kwargs[:priority] = "3"
+        else
+            nanosoldier_error("invalid priority '$priority_str': must be 'high', 'normal', or 'low'")
+        end
+    end
+
     return name, args, kwargs
 end
+
+const DEFAULT_PRIORITY = "2"
+priority(sub::JobSubmission) = parse(Int, get(sub.kwargs, :priority, DEFAULT_PRIORITY))
 
 function reply_status(sub::JobSubmission, state, context, description, url=nothing)
     if haskey(ENV, "NANOSOLDIER_DRYRUN")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,6 +109,21 @@ job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel, configu
 job = build_test_submission(PkgEvalJob, "@nanosoldier `runtests($pkgsel, configuration=(buildflags=[\"FOO=BAR\"], ))`")
 @test job.configuration.buildflags == ["FOO=BAR"]
 
+# Test priority parsing
+job = build_test_submission(BenchmarkJob, "@nanosoldier `runbenchmarks()`")  # default priority
+@test job.priority == 2
+
+job = build_test_submission(BenchmarkJob, "@nanosoldier `runbenchmarks(priority=\"high\")`")
+@test job.priority == 1
+
+job = build_test_submission(BenchmarkJob, "@nanosoldier `runbenchmarks(priority=\"normal\")`")
+@test job.priority == 2
+
+job = build_test_submission(BenchmarkJob, "@nanosoldier `runbenchmarks(priority=\"low\")`")
+@test job.priority == 3
+
+@test_throws Exception build_test_submission(BenchmarkJob, "@nanosoldier `runbenchmarks(priority=\"invalid\")`")
+
 #############################
 # retrieval from job queue  #
 #############################
@@ -160,6 +175,28 @@ queue = [daily_job, non_daily_job]
 job = Nanosoldier.retrieve_job!(queue, Any, false)
 @test job !== nothing && !job.isdaily
 @test length(queue) == 1
+
+# Test priority queue ordering
+high_priority_job = build_test_submission(BenchmarkJob, "@nanosoldier `runbenchmarks(priority=\"high\")`")
+low_priority_job = build_test_submission(BenchmarkJob, "@nanosoldier `runbenchmarks(priority=\"low\")`")
+normal_priority_job = build_test_submission(BenchmarkJob, "@nanosoldier `runbenchmarks(priority=\"normal\")`")
+
+queue = [low_priority_job, high_priority_job, normal_priority_job]
+
+# Test that high priority jobs are retrieved first
+job = Nanosoldier.retrieve_job!(queue, BenchmarkJob, true)
+@test job !== nothing && job.priority == 1  # high priority
+@test length(queue) == 2
+
+# Test that normal priority jobs are retrieved before low priority
+job = Nanosoldier.retrieve_job!(queue, BenchmarkJob, true)
+@test job !== nothing && job.priority == 2  # normal priority
+@test length(queue) == 1
+
+# Test that low priority jobs are retrieved last
+job = Nanosoldier.retrieve_job!(queue, BenchmarkJob, true)
+@test job !== nothing && job.priority == 3  # low priority
+@test length(queue) == 0
 
 #########################
 # job report generation #


### PR DESCRIPTION
:man: 

I got a bit annoyed how long I have to wait in queue for PkgEval submission for the release branches so with this I feel I can sneak past the queue...

-----

:robot: 

- Add priority field to BenchmarkJob and PkgEvalJob structs
- Support priority parsing from submission strings (high/normal/low)
- Implement priority-aware retrieval in retrieve_job\! to select highest priority jobs
- Add priority tests
- Default priority is normal (2), with high (1) and low (3) options

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>