### PR TITLE
Benchmark worker updates. Add CI for the provisioning script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,14 @@ jobs:
           # julia can instantiate the project
           sudo -u nanosoldier sh -c "\$HOME/.juliaup/bin/julia --color=yes --project=$PWD -e 'using Pkg; Pkg.status()'"
 
+          # Nanosoldier loads successfully
+          sudo -u nanosoldier sh -c "\$HOME/.juliaup/bin/julia --color=yes --project=$PWD -e 'using Nanosoldier'"
+
+          # shell scripts parse without syntax errors
+          bash -n res/provision-server.sh
+          bash -n res/provision-worker.sh
+          bash -n res/run_base_ci
+
           # tmux installed
           tmux -V
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     branches: [master]
     tags: ["*"]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 jobs:
   provision:
     name: Test provision scripts
@@ -15,7 +18,12 @@ jobs:
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Run provision-server.sh
-        run: ./res/provision-server.sh
+        run: |
+          # provision-server.sh runs julia as nanosoldier to instantiate the project,
+          # so the checkout and all ancestor dirs need to be traversable
+          dir="$PWD"; while [[ "$dir" != "/" ]]; do sudo chmod o+x "$dir"; dir=$(dirname "$dir"); done
+          chmod -R o+rX .
+          ./res/provision-server.sh
 
       - name: Verify provisioning
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,38 @@ on:
     tags: ["*"]
   pull_request:
 jobs:
+  provision:
+    name: Test provision scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Allow unprivileged user namespaces"
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Run provision-server.sh
+        run: ./res/provision-server.sh
+
+      - name: Verify provisioning
+        run: |
+          set -eux
+          # user was created with home dir
+          id nanosoldier
+          test -d ~nanosoldier
+
+          # juliaup installed and configured
+          sudo -u nanosoldier sh -c '$HOME/.juliaup/bin/juliaup --version'
+          sudo -u nanosoldier sh -c '$HOME/.juliaup/bin/juliaup config'
+
+          # ssh key generated
+          test -f ~nanosoldier/.ssh/id_ed25519.pub
+
+          # julia can instantiate the project
+          sudo -u nanosoldier sh -c "\$HOME/.juliaup/bin/julia --project=$PWD/res -e 'using Pkg; Pkg.status()'"
+
+          # tmux installed
+          tmux -V
+
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,14 @@ jobs:
 
           # juliaup installed and configured
           sudo -u nanosoldier sh -c '$HOME/.juliaup/bin/juliaup --version'
-          sudo -u nanosoldier sh -c '$HOME/.juliaup/bin/juliaup config'
+          sudo -u nanosoldier sh -c '$HOME/.juliaup/bin/juliaup config manifestversiondetect'
+          sudo -u nanosoldier sh -c '$HOME/.juliaup/bin/juliaup config autoinstallchannels'
 
           # ssh key generated
           test -f ~nanosoldier/.ssh/id_ed25519.pub
 
           # julia can instantiate the project
-          sudo -u nanosoldier sh -c "\$HOME/.juliaup/bin/julia --project=$PWD/res -e 'using Pkg; Pkg.status()'"
+          sudo -u nanosoldier sh -c "\$HOME/.juliaup/bin/julia --color=yes --project=$PWD -e 'using Pkg; Pkg.status()'"
 
           # tmux installed
           tmux -V

--- a/README.md
+++ b/README.md
@@ -237,6 +237,69 @@ request on a package repository. The execution cycle is slightly different:
   registry (implying that your `Project.toml` should contain a version bump). The `vs` side
   of the comparison will use an unmodified version of the registry.
 
+In addition, a rendered version of the report as well as the logs for each package are uploaded to AWS, and will be posted as a reply on GitHub where the job was invoked.
+
+## Initial Setup for BenchmarksJob
+
+On all computers:
+```
+echo "if this is a shared machine, you must use a password to secure this:"
+[ -f ~/.ssh/id_rsa ] || ssh-keygen -f ~/.ssh/id_rsa
+echo "add to https://github.com/settings/keys:"
+cat ~/.ssh/id_rsa.pub
+EDITOR=vim git config --global --edit
+sudo mkdir /nanosoldier
+sudo chown `whoami` /nanosoldier
+cd /nanosoldier
+git clone <URL>
+cd ./Nanosoldier.jl
+git checkout <branch>
+./provision-<worker|server>.sh
+```
+
+On main server:
+```
+scp ~nanosoldier/.ssh/id_rsa ~nanosoldier/.ssh/id_rsa.pub <workers>:
+ssh -t <workers> sudo chown nanosoldier:nanosoldier id_rsa id_rsa.pub
+ssh -t <workers> sudo mv id_rsa id_rsa.pub ~nanosoldier/.ssh
+ssh -t <workers> sudo -u nanosoldier cat .ssh/id_rsa.pub >> .ssh/authorized_keys
+ssh -t <workers> sudo -u nanosoldier "bash -c 'cat ~nanosoldier/.ssh/id_rsa.pub >> ~nanosoldier/.ssh/authorized_keys'"
+sudo -u nanosoldier ssh <workers> exit
+# repeat above for every worker, then:
+sudo -u nanosoldier scp ~nanosoldier/.ssh/known_hosts <workers>:.ssh
+```
+
+To run:
+
+```
+cd /nanosoldier/Nanosoldier.jl
+byobu
+./run_base_ci
+```
+
+## Upgrading for BenchmarksJob
+
+# on server
+```
+cd /nanosoldier/Nanosoldier.jl
+git pull
+sed -i -e 's/\<1\.6\.6\>/1.8.2/' provision-server.sh run_base_ci README.md
+chmod 666 *.toml
+sudo -u nanosoldier ../julia-1.8.2/bin/julia --project=. -e 'using Pkg; Pkg.update()'
+chmod 664 *.toml
+./provision-server.sh
+git add -u
+git commit
+git push
+```
+
+# on each worker
+```
+cd /nanosoldier/Nanosoldier.jl
+git pull
+./provision-worker.sh
+```
+
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ cd /nanosoldier
 git clone <URL>
 cd ./Nanosoldier.jl
 git checkout <branch>
-./provision-<worker|server>.sh
+./res/provision-<worker|server>.sh
 ```
 
 On main server:
@@ -287,7 +287,7 @@ git pull
 chmod 666 *.toml
 sudo -u nanosoldier $(ls -d ../julia-*/bin/julia | sort -V | tail -1) --project=. -e 'using Pkg; Pkg.update()'
 chmod 664 *.toml
-./provision-server.sh
+./res/provision-server.sh
 git add -u
 git commit
 git push
@@ -298,7 +298,7 @@ git push
 ```sh
 cd /nanosoldier/Nanosoldier.jl
 git pull
-./provision-worker.sh
+./res/provision-worker.sh
 ```
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ byobu
 cd /nanosoldier/Nanosoldier.jl
 git pull
 chmod 666 *.toml
-sudo -u nanosoldier $(ls -d ../julia-*/bin/julia | sort -V | tail -1) --project=. -e 'using Pkg; Pkg.update()'
+sudo -u nanosoldier sh -c '$HOME/.juliaup/bin/julia --project=. -e '\''using Pkg; Pkg.update()'\'''
 chmod 664 *.toml
 ./res/provision-server.sh
 git add -u

--- a/README.md
+++ b/README.md
@@ -244,9 +244,9 @@ In addition, a rendered version of the report as well as the logs for each packa
 On all computers:
 ```
 echo "if this is a shared machine, you must use a password to secure this:"
-[ -f ~/.ssh/id_rsa ] || ssh-keygen -f ~/.ssh/id_rsa
+[ -f ~/.ssh/id_ed25519.pub ] || ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519
 echo "add to https://github.com/settings/keys:"
-cat ~/.ssh/id_rsa.pub
+cat ~/.ssh/id_ed25519.pub
 EDITOR=vim git config --global --edit
 sudo mkdir /nanosoldier
 sudo chown `whoami` /nanosoldier
@@ -259,11 +259,11 @@ git checkout <branch>
 
 On main server:
 ```
-scp ~nanosoldier/.ssh/id_rsa ~nanosoldier/.ssh/id_rsa.pub <workers>:
-ssh -t <workers> sudo chown nanosoldier:nanosoldier id_rsa id_rsa.pub
-ssh -t <workers> sudo mv id_rsa id_rsa.pub ~nanosoldier/.ssh
-ssh -t <workers> sudo -u nanosoldier cat .ssh/id_rsa.pub >> .ssh/authorized_keys
-ssh -t <workers> sudo -u nanosoldier "bash -c 'cat ~nanosoldier/.ssh/id_rsa.pub >> ~nanosoldier/.ssh/authorized_keys'"
+scp ~nanosoldier/.ssh/id_ed25519 ~nanosoldier/.ssh/id_ed25519.pub <workers>:
+ssh -t <workers> sudo chown nanosoldier:nanosoldier id_ed25519 id_ed25519.pub
+ssh -t <workers> sudo mv id_ed25519 id_ed25519.pub ~nanosoldier/.ssh
+ssh -t <workers> sudo -u nanosoldier cat .ssh/id_ed25519.pub >> .ssh/authorized_keys
+ssh -t <workers> sudo -u nanosoldier "bash -c 'cat ~nanosoldier/.ssh/id_ed25519.pub >> ~nanosoldier/.ssh/authorized_keys'"
 sudo -u nanosoldier ssh <workers> exit
 # repeat above for every worker, then:
 sudo -u nanosoldier scp ~nanosoldier/.ssh/known_hosts <workers>:.ssh
@@ -279,13 +279,13 @@ byobu
 
 ## Upgrading for BenchmarksJob
 
-# on server
-```
+### On server
+
+```sh
 cd /nanosoldier/Nanosoldier.jl
 git pull
-sed -i -e 's/\<1\.6\.6\>/1.8.2/' provision-server.sh run_base_ci README.md
 chmod 666 *.toml
-sudo -u nanosoldier ../julia-1.8.2/bin/julia --project=. -e 'using Pkg; Pkg.update()'
+sudo -u nanosoldier $(ls -d ../julia-*/bin/julia | sort -V | tail -1) --project=. -e 'using Pkg; Pkg.update()'
 chmod 664 *.toml
 ./provision-server.sh
 git add -u
@@ -293,13 +293,13 @@ git commit
 git push
 ```
 
-# on each worker
-```
+### On each worker
+
+```sh
 cd /nanosoldier/Nanosoldier.jl
 git pull
 ./provision-worker.sh
 ```
-
 
 ## Acknowledgements
 

--- a/bin/run_base_ci.jl
+++ b/bin/run_base_ci.jl
@@ -1,7 +1,7 @@
 using Distributed
 import Nanosoldier, GitHub, Sockets
 
-nodes = Dict(Any => addprocs(1))
+nodes = Dict(Any => addprocs(1; exeflags="--project=$(ENV["JULIA_PROJECT"])"))
 @everywhere import Nanosoldier
 
 auth = GitHub.authenticate("GITHUB_AUTH00000000000000000000000000000")

--- a/res/README.md
+++ b/res/README.md
@@ -17,6 +17,16 @@ following properties:
 
 ## BenchmarkJob
 
+Julia is managed via [juliaup](https://github.com/JuliaLang/juliaup). The provision scripts
+install it for the `nanosoldier` user and configure two settings:
+
+- `manifestversiondetect true` — automatically selects the Julia version matching the
+  `julia_version` field in `Manifest.toml`, so no hardcoded version is needed anywhere.
+- `autoinstallchannels true` — automatically installs any required Julia version on first use.
+
+To update Julia, update `Manifest.toml` (e.g. via `Pkg.update()` with the new version) and
+juliaup will install and use the new version automatically on the next run.
+
 On all computers:
 
 ```
@@ -63,7 +73,7 @@ byobu
 cd /nanosoldier/Nanosoldier.jl
 git pull
 chmod 666 *.toml
-sudo -u nanosoldier ../julia-1.6.6/bin/julia --project=. -e 'using Pkg; Pkg.update()'
+sudo -u nanosoldier sh -c '$HOME/.juliaup/bin/julia --project=. -e '\''using Pkg; Pkg.update()'\'''
 chmod 664 *.toml
 ./provision-server.sh
 git add -u

--- a/res/README.md
+++ b/res/README.md
@@ -21,9 +21,9 @@ On all computers:
 
 ```
 echo "if this is a shared machine, you must use a password to secure this:"
-[ -f ~/.ssh/id_rsa ] || ssh-keygen -f ~/.ssh/id_rsa
+[ -f ~/.ssh/id_ed25519.pub ] || ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519
 echo "add to https://github.com/settings/keys:"
-cat ~/.ssh/id_rsa.pub
+cat ~/.ssh/id_ed25519.pub
 EDITOR=vim git config --global --edit
 sudo mkdir /nanosoldier
 sudo chown `whoami` /nanosoldier
@@ -37,11 +37,11 @@ git checkout <branch>
 On main server:
 
 ```
-scp ~nanosoldier/.ssh/id_rsa ~nanosoldier/.ssh/id_rsa.pub <workers>:
-ssh -t <workers> sudo chown nanosoldier:nanosoldier id_rsa id_rsa.pub
-ssh -t <workers> sudo mv id_rsa id_rsa.pub ~nanosoldier/.ssh
-ssh -t <workers> sudo -u nanosoldier cat .ssh/id_rsa.pub >> .ssh/authorized_keys
-ssh -t <workers> sudo -u nanosoldier "bash -c 'cat ~nanosoldier/.ssh/id_rsa.pub >> ~nanosoldier/.ssh/authorized_keys'"
+scp ~nanosoldier/.ssh/id_ed25519 ~nanosoldier/.ssh/id_ed25519.pub <workers>:
+ssh -t <workers> sudo chown nanosoldier:nanosoldier id_ed25519 id_ed25519.pub
+ssh -t <workers> sudo mv id_ed25519 id_ed25519.pub ~nanosoldier/.ssh
+ssh -t <workers> sudo -u nanosoldier cat .ssh/id_ed25519.pub >> .ssh/authorized_keys
+ssh -t <workers> sudo -u nanosoldier "bash -c 'cat ~nanosoldier/.ssh/id_ed25519.pub >> ~nanosoldier/.ssh/authorized_keys'"
 sudo -u nanosoldier ssh <workers> exit
 # repeat above for every worker, then:
 sudo -u nanosoldier scp ~nanosoldier/.ssh/known_hosts <workers>:.ssh

--- a/res/provision-server.sh
+++ b/res/provision-server.sh
@@ -18,9 +18,9 @@ sudo -u nanosoldier sh -c '$HOME/.juliaup/bin/juliaup config manifestversiondete
 sudo -u nanosoldier sh -c '$HOME/.juliaup/bin/juliaup config autoinstallchannels true'
 
 sudo -u nanosoldier [ -f ~nanosoldier/.ssh/id_ed25519.pub ] || sudo -u nanosoldier ssh-keygen -N '' -f ~nanosoldier/.ssh/id_ed25519 -t ed25519
-sudo -u nanosoldier git config --global user.name "nanosoldier"
-sudo -u nanosoldier git config --global user.email "nanosoldierjulia@gmail.com"
-sudo -u nanosoldier ssh -T git@github.com || true
+sudo -u nanosoldier sh -c 'cd && git config --global user.name "nanosoldier"'
+sudo -u nanosoldier sh -c 'cd && git config --global user.email "nanosoldierjulia@gmail.com"'
+sudo -u nanosoldier sh -c 'cd && ssh -T git@github.com' || true
 
 [ -d PkgEval.jl ] || git clone https://github.com/JuliaCI/PkgEval.jl
 sudo -u nanosoldier sh -c "\$HOME/.juliaup/bin/julia --project=$HERE -e 'using Pkg; Pkg.instantiate()'"

--- a/res/provision-server.sh
+++ b/res/provision-server.sh
@@ -23,7 +23,7 @@ sudo -u nanosoldier sh -c 'cd && git config --global user.email "nanosoldierjuli
 sudo -u nanosoldier sh -c 'cd && ssh -T git@github.com' || true
 
 [ -d PkgEval.jl ] || git clone https://github.com/JuliaCI/PkgEval.jl
-sudo -u nanosoldier sh -c "\$HOME/.juliaup/bin/julia --project=$HERE/.. -e 'using Pkg; Pkg.instantiate()'"
+sudo -u nanosoldier sh -c "\$HOME/.juliaup/bin/julia --color=yes --project=$HERE/.. -e 'using Pkg; Pkg.instantiate()'"
 
 set +v
 

--- a/res/provision-server.sh
+++ b/res/provision-server.sh
@@ -4,12 +4,6 @@ set -euv -o pipefail
 HERE=`realpath $(dirname $0)`
 cd "$HERE/.."
 
-VERSION=1.10.7
-
-MAJOR=`echo $VERSION | cut -d . -f 1`
-MINOR=`echo $VERSION | cut -d . -f 2`
-PATCH=`echo $VERSION | cut -d . -f 3`
-
 sudo apt update
 sudo apt install -y tmux
 
@@ -19,14 +13,17 @@ sudo usermod -aG nanosoldier `whoami`
 echo "`whoami` ALL= (nanosoldier) NOPASSWD: ALL
 Defaults> nanosoldier umask=0777" | sudo tee -a /etc/sudoers.d/99-nanosoldier
 
+sudo -u nanosoldier sh -c '[ -x "$HOME/.juliaup/bin/juliaup" ] || curl -fsSL https://install.julialang.org | sh -s -- --yes'
+sudo -u nanosoldier sh -c '$HOME/.juliaup/bin/juliaup config manifestversiondetect true'
+sudo -u nanosoldier sh -c '$HOME/.juliaup/bin/juliaup config autoinstallchannels true'
+
 sudo -u nanosoldier [ -f ~nanosoldier/.ssh/id_ed25519.pub ] || sudo -u nanosoldier ssh-keygen -N '' -f ~nanosoldier/.ssh/id_ed25519 -t ed25519
 sudo -u nanosoldier git config --global user.name "nanosoldier"
 sudo -u nanosoldier git config --global user.email "nanosoldierjulia@gmail.com"
 sudo -u nanosoldier ssh -T git@github.com || true
 
-[ -d julia-$VERSION ] || curl -fL https://julialang-s3.julialang.org/bin/linux/x64/$MAJOR.$MINOR/julia-$VERSION-linux-x86_64.tar.gz | tar xz
 [ -d PkgEval.jl ] || git clone https://github.com/JuliaCI/PkgEval.jl
-sudo -u nanosoldier julia-$VERSION/bin/julia --project=$HERE -e 'using Pkg; Pkg.instantiate()'
+sudo -u nanosoldier sh -c "\$HOME/.juliaup/bin/julia --project=$HERE -e 'using Pkg; Pkg.instantiate()'"
 
 set +v
 
@@ -64,7 +61,7 @@ echo "  export GITHUB_SECRET=<random-string>"
 echo "  export GITHUB_PORT=<random-port>"
 echo "  export JULIA_PROJECT=`dirname $0`"
 echo "  . ../cset/bin/activate"
-echo "  setarch -R ../julia-$VERSION/bin/julia -L bin/setup_test_ci.jl -e 'using Sockets; run(server, IPv4(0), ENV[\"GITHUB_PORT\"])'"
+echo "  setarch -R \$HOME/.juliaup/bin/julia -L bin/setup_test_ci.jl -e 'using Sockets; run(server, IPv4(0), ENV[\"GITHUB_PORT\"])'"
 echo
 echo "or with a helper script:"
 echo "  (umask 007 && cp bin/run_base_ci.jl ..)"

--- a/res/provision-server.sh
+++ b/res/provision-server.sh
@@ -4,19 +4,21 @@ set -euv -o pipefail
 HERE=`realpath $(dirname $0)`
 cd "$HERE/.."
 
-VERSION=1.6.6
+VERSION=1.8.2
 
 MAJOR=`echo $VERSION | cut -d . -f 1`
 MINOR=`echo $VERSION | cut -d . -f 2`
 PATCH=`echo $VERSION | cut -d . -f 3`
 
+sudo apt update
+
 # create a (non-privileged) user to run the server:
-sudo useradd nanosoldier || true
+sudo useradd -m nanosoldier || true
 sudo usermod -aG nanosoldier `whoami`
 echo "`whoami` ALL= (nanosoldier) NOPASSWD: ALL
 Defaults> nanosoldier umask=0777" | sudo tee -a /etc/sudoers.d/99-nanosoldier
 
-sudo -u nanosoldier [ -f ~nanosoldier/.ssh/id_rsa.pub ] || sudo -u nanosoldier ssh-keygen -N '' -f ~nanosoldier/.ssh/id_rsa
+sudo -u nanosoldier [ -f ~nanosoldier/.ssh/id_ed25519.pub ] || sudo -u nanosoldier ssh-keygen -N '' -f ~nanosoldier/.ssh/id_ed25519 -t ed25519
 sudo -u nanosoldier git config --global user.name "nanosoldier"
 sudo -u nanosoldier git config --global user.email "nanosoldierjulia@gmail.com"
 sudo -u nanosoldier ssh -T git@github.com || true
@@ -34,8 +36,8 @@ echo "-------------"
 echo
 echo "install this ssh key in github for user @nanosoldier at"
 echo "  https://github.com/settings/ssh/new"
-echo "  and on all worker machines at ~nanosoldier/.ssh/authorized_keys"
-sudo -u nanosoldier cat ~nanosoldier/.ssh/id_rsa.pub
+echo "and on all worker machines at ~nanosoldier/.ssh/authorized_keys"
+sudo -u nanosoldier cat ~nanosoldier/.ssh/id_ed25519.pub
 echo
 echo "and generate an auth-token for later at"
 echo "  https://github.com/settings/tokens/new"
@@ -64,8 +66,8 @@ echo "  . ../cset/bin/activate"
 echo "  setarch -R ../julia-$VERSION/bin/julia -L bin/setup_test_ci.jl -e 'using Sockets; run(server, IPv4(0), ENV[\"GITHUB_PORT\"])'"
 echo
 echo "or with a helper script:"
-echo "  cp bin/run_base_ci.jl .."
-echo "  chgrp nanosoldier ../run_base_ci.jl"
-echo "  chmod 660 ../run_base_ci.jl"
+echo "  (umask 007 && cp bin/run_base_ci.jl ..)"
+echo "  (umask 007 && touch ../run_base_ci.stdout ../run_base_ci.stderr)"
+echo "  sudo chgrp nanosoldier ../run_base_ci.jl ../run_base_ci.stdout ../run_base_ci.stderr"
 echo "  \${EDITOR:-vim} ../run_base_ci.jl"
-echo "  sudo -u nanosoldier nohup ./run_base_ci"
+echo "  ./run_base_ci"

--- a/res/provision-server.sh
+++ b/res/provision-server.sh
@@ -17,7 +17,7 @@ sudo -u nanosoldier sh -c '[ -x "$HOME/.juliaup/bin/juliaup" ] || curl -fsSL htt
 sudo -u nanosoldier sh -c '$HOME/.juliaup/bin/juliaup config manifestversiondetect true'
 sudo -u nanosoldier sh -c '$HOME/.juliaup/bin/juliaup config autoinstallchannels true'
 
-sudo -u nanosoldier sh -c 'cd && mkdir -p .ssh && [ -f .ssh/id_ed25519.pub ] || ssh-keygen -N "" -f .ssh/id_ed25519 -t ed25519'
+sudo -u nanosoldier sh -c 'cd && mkdir -p .ssh && { [ -f .ssh/id_ed25519.pub ] || ssh-keygen -N "" -f .ssh/id_ed25519 -t ed25519; }'
 sudo -u nanosoldier sh -c 'cd && git config --global user.name "nanosoldier"'
 sudo -u nanosoldier sh -c 'cd && git config --global user.email "nanosoldierjulia@gmail.com"'
 sudo -u nanosoldier sh -c 'cd && ssh -T git@github.com' || true

--- a/res/provision-server.sh
+++ b/res/provision-server.sh
@@ -17,7 +17,7 @@ sudo -u nanosoldier sh -c '[ -x "$HOME/.juliaup/bin/juliaup" ] || curl -fsSL htt
 sudo -u nanosoldier sh -c '$HOME/.juliaup/bin/juliaup config manifestversiondetect true'
 sudo -u nanosoldier sh -c '$HOME/.juliaup/bin/juliaup config autoinstallchannels true'
 
-sudo -u nanosoldier [ -f ~nanosoldier/.ssh/id_ed25519.pub ] || sudo -u nanosoldier ssh-keygen -N '' -f ~nanosoldier/.ssh/id_ed25519 -t ed25519
+sudo -u nanosoldier sh -c 'cd && mkdir -p .ssh && [ -f .ssh/id_ed25519.pub ] || ssh-keygen -N "" -f .ssh/id_ed25519 -t ed25519'
 sudo -u nanosoldier sh -c 'cd && git config --global user.name "nanosoldier"'
 sudo -u nanosoldier sh -c 'cd && git config --global user.email "nanosoldierjulia@gmail.com"'
 sudo -u nanosoldier sh -c 'cd && ssh -T git@github.com' || true

--- a/res/provision-server.sh
+++ b/res/provision-server.sh
@@ -11,6 +11,7 @@ MINOR=`echo $VERSION | cut -d . -f 2`
 PATCH=`echo $VERSION | cut -d . -f 3`
 
 sudo apt update
+sudo apt install -y tmux
 
 # create a (non-privileged) user to run the server:
 sudo useradd -m nanosoldier || true

--- a/res/provision-server.sh
+++ b/res/provision-server.sh
@@ -4,7 +4,7 @@ set -euv -o pipefail
 HERE=`realpath $(dirname $0)`
 cd "$HERE/.."
 
-VERSION=1.8.2
+VERSION=1.10.7
 
 MAJOR=`echo $VERSION | cut -d . -f 1`
 MINOR=`echo $VERSION | cut -d . -f 2`

--- a/res/provision-server.sh
+++ b/res/provision-server.sh
@@ -23,7 +23,7 @@ sudo -u nanosoldier sh -c 'cd && git config --global user.email "nanosoldierjuli
 sudo -u nanosoldier sh -c 'cd && ssh -T git@github.com' || true
 
 [ -d PkgEval.jl ] || git clone https://github.com/JuliaCI/PkgEval.jl
-sudo -u nanosoldier sh -c "\$HOME/.juliaup/bin/julia --project=$HERE -e 'using Pkg; Pkg.instantiate()'"
+sudo -u nanosoldier sh -c "\$HOME/.juliaup/bin/julia --project=$HERE/.. -e 'using Pkg; Pkg.instantiate()'"
 
 set +v
 

--- a/res/provision-worker.sh
+++ b/res/provision-worker.sh
@@ -9,7 +9,6 @@ set +v
 # See https://juliaci.github.io/BenchmarkTools.jl/stable/linuxtips/
 # for an explanation of these configuration options
 
-sudo apt update
 sudo apt install build-essential libatomic1 python3 gfortran perl wget m4 cmake pkg-config curl ninja-build ccache
 sudo apt install virtualenv
 virtualenv cset
@@ -43,7 +42,7 @@ cat /proc/interrupts
 # irqbalance
 
 # create a (non-privileged) user to run the build and test:
-sudo useradd nanosoldier-worker || true
+sudo useradd -m nanosoldier-worker || true
 sudo usermod -aG nanosoldier-worker `whoami`
 sudo usermod -aG nanosoldier-worker nanosoldier
 
@@ -66,4 +65,7 @@ echo "-------------"
 echo "manual steps (for each worker)"
 echo "-------------"
 echo
-echo "replace ~nanosoldier/.ssh/id_rsa* with those files from the master"
+echo "install ssh key from master server to this worker"
+echo "sudo -u nanosoldier vim ~nanosoldier/.ssh/authorized_keys"
+echo "sudo -u nanosoldier chmod 600 ~nanosoldier/.ssh/authorized_keys"
+echo " # on server # sudo -u nanosoldier scp /home/nanosoldier/.ssh/id_ed25519 /home/nanosoldier/.ssh/id_ed25519.pub `hostname`:.ssh"

--- a/res/run_base_ci
+++ b/res/run_base_ci
@@ -7,7 +7,7 @@ cd ..
 echo $JULIA_PROJECT
 JULIA_VERSION=$(ls -d julia-*/bin/julia | sort -V | tail -1 | cut -d/ -f1 | sed 's/julia-//')
 exec sudo -u nanosoldier --preserve-env=JULIA_PROJECT \
-    tmux new bash -c " \
+    tmux new-session -A -s nanosoldier bash -c " \
     setarch -R julia-$JULIA_VERSION/bin/julia run_base_ci.jl \
     2> >(umask 007 && exec setsid -w tee -a run_base_ci.stderr) \
     1> >(umask 007 && exec setsid -w tee -a run_base_ci.stdout)"

--- a/res/run_base_ci
+++ b/res/run_base_ci
@@ -5,9 +5,8 @@ cd "`dirname $0`"
 export JULIA_PROJECT=~+
 cd ..
 echo $JULIA_PROJECT
-JULIA_VERSION=$(ls -d julia-*/bin/julia | sort -V | tail -1 | cut -d/ -f1 | sed 's/julia-//')
 exec sudo -u nanosoldier --preserve-env=JULIA_PROJECT \
     tmux new-session -A -s nanosoldier bash -c " \
-    setarch -R julia-$JULIA_VERSION/bin/julia run_base_ci.jl \
+    setarch -R \$HOME/.juliaup/bin/julia run_base_ci.jl \
     2> >(umask 007 && exec setsid -w tee -a run_base_ci.stderr) \
     1> >(umask 007 && exec setsid -w tee -a run_base_ci.stdout)"

--- a/res/run_base_ci
+++ b/res/run_base_ci
@@ -5,8 +5,9 @@ cd "`dirname $0`"
 export JULIA_PROJECT=~+
 cd ..
 echo $JULIA_PROJECT
+JULIA_VERSION=$(ls -d julia-*/bin/julia | sort -V | tail -1 | cut -d/ -f1 | sed 's/julia-//')
 exec sudo -u nanosoldier --preserve-env=JULIA_PROJECT \
     tmux new bash -c " \
-    setarch -R julia-1.8.2/bin/julia run_base_ci.jl \
+    setarch -R julia-$JULIA_VERSION/bin/julia run_base_ci.jl \
     2> >(umask 007 && exec setsid -w tee -a run_base_ci.stderr) \
     1> >(umask 007 && exec setsid -w tee -a run_base_ci.stdout)"

--- a/res/run_base_ci
+++ b/res/run_base_ci
@@ -6,6 +6,7 @@ export JULIA_PROJECT=~+
 cd ..
 echo $JULIA_PROJECT
 exec sudo -u nanosoldier --preserve-env=JULIA_PROJECT \
-    setarch -R julia-1.6.6/bin/julia run_base_ci.jl \
-    2> >(umask 007 && exec sudo -u nanosoldier setsid -w tee -a run_base_ci.stderr) \
-    1> >(umask 007 && exec sudo -u nanosoldier setsid -w tee -a run_base_ci.stdout)
+    tmux new bash -c " \
+    setarch -R julia-1.8.2/bin/julia run_base_ci.jl \
+    2> >(umask 007 && exec setsid -w tee -a run_base_ci.stderr) \
+    1> >(umask 007 && exec setsid -w tee -a run_base_ci.stdout)"

--- a/src/build.jl
+++ b/src/build.jl
@@ -53,7 +53,7 @@ function build_julia!(config::Config, build::BuildRef, logpath, prnumber::Union{
     mirrordir = joinpath(workdir, "mirrors", "julia")
     mkpath(dirname(mirrordir), mode=0o755)
     mkpidlock(mirrordir * ".lock") do
-        if ispath(mirrordir, ".git")
+        if ispath(mirrordir, "config")
             run(`$(git()) -C $mirrordir fetch --quiet --all`)
         else
             mkpath(mirrordir)

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -363,7 +363,7 @@ function execute_benchmarks!(job::BenchmarkJob, juliapath, whichbuild::Symbol)
         run(`$(git()) -C $BaseBenchmarks reset --hard --quiet origin/$(branchname)`)
     end
 
-    run(sudo(cfg.user, setenv(`$(setenv(juliacmd, nothing)) -e 'using Pkg; Pkg.instantiate(); Pkg.status()'`; dir=builddir)))
+    run(sudo(cfg.user, `$(setenv(juliacmd, nothing, dir=builddir)) -e 'using Pkg; Pkg.instantiate(); Pkg.status()'`))
 
     cset = abspath("cset/bin/cset")
     # The following code sets up a CPU shield, then spins up a new julia process on the
@@ -431,7 +431,7 @@ function execute_benchmarks!(job::BenchmarkJob, juliapath, whichbuild::Symbol)
 
                           println("SETTING UP FOR RUN...")
                           # move ourselves onto the first CPU in the shielded set
-                          run(`sudo -n -- $cset proc -m -p \$(getpid()) -t /user/child`))
+                          run(`sudo -n -- $cset proc -m -p \$(getpid()) -t /user/child`)
                           BLAS.set_num_threads(1) # ensure BLAS threads do not trample each other
                           addprocs(1)             # add worker that can be used by parallel benchmarks
 
@@ -487,7 +487,7 @@ function execute_benchmarks!(job::BenchmarkJob, juliapath, whichbuild::Symbol)
     run(sudo(`$cset set -d /user/child`))
     run(sudo(`$cset shield --reset`))
 
-    results = BenchmarkTools.load(benchresults)[1]
+    minresults = BenchmarkTools.load(benchminimum)[1]
 
     # Get the verbose output of versioninfo for the build, throwing away
     # environment information that is useless/potentially risky to expose.
@@ -505,7 +505,7 @@ function execute_benchmarks!(job::BenchmarkJob, juliapath, whichbuild::Symbol)
     # delete the builddir now that we're done with it
     rm(builddir, recursive=true)
 
-    return minimum(results), vinfo
+    return minresults, vinfo
 end
 
 ##########################


### PR DESCRIPTION
Rebased version of #125 

- ensure `!has_nondefault_cmd_flags`
- corrected path for bare repository (`.git` → `config`)
- fix `setenv` call and `benchminimum` variable from #121
- switch xz to zstd
- fixes and clarifications for provision scripts
  - switch ssh key refs from RSA to Ed25519
  - use `$HOME` instead of `~` in sudo/sh contexts
  - `useradd -m` for home dir creation
  - install tmux
- move `run_base_ci` to run in tmux as nanosoldier (`tmux new-session -A -s nanosoldier`)
- propagate `--project` to worker processes in `run_base_ci.jl`
- add setup/upgrade documentation to README
- use juliaup with `manifestversiondetect` and `autoinstallchannels` instead of hardcoded Julia version/tarball