### PR TITLE
Run benchmarks individually, store only minimum estimate

### DIFF
--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -391,9 +391,6 @@ function execute_benchmarks!(job::BenchmarkJob, juliapath, whichbuild::Symbol)
     benchout = joinpath(tmplogdir(job), string(benchname, ".out"))
     bencherr = joinpath(tmplogdir(job), string(benchname, ".err"))
     benchminimum = joinpath(tmpdatadir(job), string(benchname, ".minimum.json"))
-    benchmedian = joinpath(tmpdatadir(job), string(benchname, ".median.json"))
-    benchmean = joinpath(tmpdatadir(job), string(benchname, ".mean.json"))
-    benchstd = joinpath(tmpdatadir(job), string(benchname, ".std.json"))
 
     open(shscriptpath, "w") do file
         println(file, """
@@ -410,7 +407,6 @@ function execute_benchmarks!(job::BenchmarkJob, juliapath, whichbuild::Symbol)
                       using LinearAlgebra # needed for `BLAS.set_num_threads`
                       using BaseBenchmarks
                       using BenchmarkTools
-                      using Statistics
                       using JSON
 
                       println(now(), " | starting benchscript.jl (STDOUT/STDERR will be redirected to the result folder)")
@@ -439,13 +435,25 @@ function execute_benchmarks!(job::BenchmarkJob, juliapath, whichbuild::Symbol)
                           warmup(benchmarks)
 
                           println("RUNNING BENCHMARKS...")
-                          results = run(benchmarks; verbose=true)
+                          # Run each benchmark individually and keep only the minimum
+                          # estimate, so that the full Trial sample data can be GC'd
+                          # between benchmarks instead of accumulating in memory.
+                          minresults = BenchmarkGroup()
+                          for (ids, benchmark) in BenchmarkTools.leaves(benchmarks)
+                              println("  benchmarking ", ids, "...")
+                              trial = run(benchmark; verbose=true)
+                              group = minresults
+                              for id in ids[1:end-1]
+                                  if !haskey(group, id)
+                                      group[id] = BenchmarkGroup()
+                                  end
+                                  group = group[id]
+                              end
+                              group[ids[end]] = minimum(trial)
+                          end
 
                           println("SAVING RESULT...")
-                          BenchmarkTools.save($(repr(benchminimum)), minimum(results))
-                          BenchmarkTools.save($(repr(benchmedian)), median(results))
-                          BenchmarkTools.save($(repr(benchmean)), mean(results))
-                          BenchmarkTools.save($(repr(benchstd)), std(results))
+                          BenchmarkTools.save($(repr(benchminimum)), minresults)
 
                           println("DONE!")
                       finally

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -391,6 +391,9 @@ function execute_benchmarks!(job::BenchmarkJob, juliapath, whichbuild::Symbol)
     benchout = joinpath(tmplogdir(job), string(benchname, ".out"))
     bencherr = joinpath(tmplogdir(job), string(benchname, ".err"))
     benchminimum = joinpath(tmpdatadir(job), string(benchname, ".minimum.json"))
+    benchmedian = joinpath(tmpdatadir(job), string(benchname, ".median.json"))
+    benchmean = joinpath(tmpdatadir(job), string(benchname, ".mean.json"))
+    benchstd = joinpath(tmpdatadir(job), string(benchname, ".std.json"))
 
     open(shscriptpath, "w") do file
         println(file, """
@@ -407,6 +410,7 @@ function execute_benchmarks!(job::BenchmarkJob, juliapath, whichbuild::Symbol)
                       using LinearAlgebra # needed for `BLAS.set_num_threads`
                       using BaseBenchmarks
                       using BenchmarkTools
+                      using Statistics
                       using JSON
 
                       println(now(), " | starting benchscript.jl (STDOUT/STDERR will be redirected to the result folder)")
@@ -435,25 +439,34 @@ function execute_benchmarks!(job::BenchmarkJob, juliapath, whichbuild::Symbol)
                           warmup(benchmarks)
 
                           println("RUNNING BENCHMARKS...")
-                          # Run each benchmark individually and keep only the minimum
-                          # estimate, so that the full Trial sample data can be GC'd
+                          # Run each benchmark individually and keep only the per-benchmark
+                          # estimates, so that the full Trial sample data can be GC'd
                           # between benchmarks instead of accumulating in memory.
                           minresults = BenchmarkGroup()
+                          medianresults = BenchmarkGroup()
+                          meanresults = BenchmarkGroup()
+                          stdresults = BenchmarkGroup()
                           for (ids, benchmark) in BenchmarkTools.leaves(benchmarks)
                               println("  benchmarking ", ids, "...")
                               trial = run(benchmark; verbose=true)
-                              group = minresults
-                              for id in ids[1:end-1]
-                                  if !haskey(group, id)
-                                      group[id] = BenchmarkGroup()
+                              for (results, f) in ((minresults, minimum), (medianresults, median),
+                                                   (meanresults, mean), (stdresults, std))
+                                  group = results
+                                  for id in ids[1:end-1]
+                                      if !haskey(group, id)
+                                          group[id] = BenchmarkGroup()
+                                      end
+                                      group = group[id]
                                   end
-                                  group = group[id]
+                                  group[ids[end]] = f(trial)
                               end
-                              group[ids[end]] = minimum(trial)
                           end
 
                           println("SAVING RESULT...")
                           BenchmarkTools.save($(repr(benchminimum)), minresults)
+                          BenchmarkTools.save($(repr(benchmedian)), medianresults)
+                          BenchmarkTools.save($(repr(benchmean)), meanresults)
+                          BenchmarkTools.save($(repr(benchstd)), stdresults)
 
                           println("DONE!")
                       finally

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -7,6 +7,7 @@
 # performed to ensure that the tag predicate is grammatically correct.
 
 const VALID_TAG_PRED_SYMS = (:!, :&&, :||, :call, :ALL)
+const MAX_BENCHMARK_ERRORS = 100
 
 function is_valid_tagpred(tagpred::AbstractString)
     parsed = Meta.parse(tagpred)
@@ -242,7 +243,7 @@ function Base.run(job::BenchmarkJob)
         # run primary job
         julia_primary = fetch(julia_primary)
         nodelog(cfg, node, "running primary build for $(summary(job))")
-        results["primary"], results["primary.vinfo"] =
+        results["primary"], results["primary.vinfo"], results["primary.errors"] =
             execute_benchmarks!(job, julia_primary, :primary)
         nodelog(cfg, node, "finished primary build for $(summary(job))")
 
@@ -272,7 +273,7 @@ function Base.run(job::BenchmarkJob)
         elseif job.against !== nothing # run comparison build
             julia_against = fetch(julia_against)
             nodelog(cfg, node, "running comparison build for $(summary(job))")
-            results["against"], results["against.vinfo"] =
+            results["against"], results["against.vinfo"], results["against.errors"] =
                 execute_benchmarks!(job, julia_against, :against)
             nodelog(cfg, node, "finished comparison build for $(summary(job))")
         end
@@ -394,6 +395,7 @@ function execute_benchmarks!(job::BenchmarkJob, juliapath, whichbuild::Symbol)
     benchmedian = joinpath(tmpdatadir(job), string(benchname, ".median.json"))
     benchmean = joinpath(tmpdatadir(job), string(benchname, ".mean.json"))
     benchstd = joinpath(tmpdatadir(job), string(benchname, ".std.json"))
+    bencherrors = joinpath(tmpdatadir(job), string(benchname, ".errors.json"))
 
     open(shscriptpath, "w") do file
         println(file, """
@@ -446,19 +448,33 @@ function execute_benchmarks!(job::BenchmarkJob, juliapath, whichbuild::Symbol)
                           medianresults = BenchmarkGroup()
                           meanresults = BenchmarkGroup()
                           stdresults = BenchmarkGroup()
+                          bencherrorlist = Vector{Pair{Vector{Any}, String}}()
                           for (ids, benchmark) in BenchmarkTools.leaves(benchmarks)
                               println("  benchmarking ", ids, "...")
-                              trial = run(benchmark; verbose=true)
-                              for (results, f) in ((minresults, minimum), (medianresults, median),
-                                                   (meanresults, mean), (stdresults, std))
-                                  group = results
-                                  for id in ids[1:end-1]
-                                      if !haskey(group, id)
-                                          group[id] = BenchmarkGroup()
+                              try
+                                  trial = run(benchmark; verbose=true)
+                                  for (results, f) in ((minresults, minimum), (medianresults, median),
+                                                       (meanresults, mean), (stdresults, std))
+                                      group = results
+                                      for id in ids[1:end-1]
+                                          if !haskey(group, id)
+                                              group[id] = BenchmarkGroup()
+                                          end
+                                          group = group[id]
                                       end
-                                      group = group[id]
+                                      group[ids[end]] = f(trial)
                                   end
-                                  group[ids[end]] = f(trial)
+                              catch err
+                                  # Log full backtrace to stderr (private log file) but only
+                                  # record the error type for the public report.
+                                  println(stderr, "  FAILED benchmark ", ids, ":")
+                                  Base.showerror(stderr, err, catch_backtrace())
+                                  println(stderr)
+                                  push!(bencherrorlist, ids => string(typeof(err)))
+                                  if length(bencherrorlist) >= $(MAX_BENCHMARK_ERRORS)
+                                      println(stderr, "  Too many benchmark errors ($(MAX_BENCHMARK_ERRORS)), aborting remaining benchmarks.")
+                                      break
+                                  end
                               end
                           end
 
@@ -467,6 +483,9 @@ function execute_benchmarks!(job::BenchmarkJob, juliapath, whichbuild::Symbol)
                           BenchmarkTools.save($(repr(benchmedian)), medianresults)
                           BenchmarkTools.save($(repr(benchmean)), meanresults)
                           BenchmarkTools.save($(repr(benchstd)), stdresults)
+                          open($(repr(bencherrors)), "w") do io
+                              JSON.print(io, [Dict("id" => ids, "error" => msg) for (ids, msg) in bencherrorlist])
+                          end
 
                           println("DONE!")
                       finally
@@ -509,6 +528,7 @@ function execute_benchmarks!(job::BenchmarkJob, juliapath, whichbuild::Symbol)
     run(sudo(`$cset shield --reset`))
 
     minresults = BenchmarkTools.load(benchminimum)[1]
+    errors = isfile(bencherrors) ? JSON.parsefile(bencherrors) : []
 
     # Get the verbose output of versioninfo for the build, throwing away
     # environment information that is useless/potentially risky to expose.
@@ -526,7 +546,7 @@ function execute_benchmarks!(job::BenchmarkJob, juliapath, whichbuild::Symbol)
     # delete the builddir now that we're done with it
     rm(builddir, recursive=true)
 
-    return minresults, vinfo
+    return minresults, vinfo, errors
 end
 
 ##########################
@@ -586,6 +606,7 @@ function report(job::BenchmarkJob, results)
         else
             "$(s.total) benchmarks were executed."
         end
+        s.errors > 0 && (summary_line *= " $(s.errors) benchmarks failed.")
         build = submission(job).build
         commit_line = "[`$(snipsha(build.sha))`](https://github.com/$(build.repo)/commit/$(build.sha))"
         if job.against !== nothing
@@ -605,25 +626,30 @@ end
 
 function countsummary(results)
     iscomparison = haskey(results, "judged")
+    nerrors = length(get(results, "primary.errors", [])) + length(get(results, "against.errors", []))
     if !iscomparison
         total = length(BenchmarkTools.leaves(results["primary"]))
-        return (total=total, regressions=0, improvements=0, iscomparison=false)
+        return (total=total, regressions=0, improvements=0, errors=nerrors, iscomparison=false)
     end
     entries = BenchmarkTools.leaves(results["judged"])
     total = length(entries)
     regressions = count(((_, t),) -> BenchmarkTools.isregression(t), entries)
     improvements = count(((_, t),) -> BenchmarkTools.isimprovement(t), entries)
-    return (total=total, regressions=regressions, improvements=improvements, iscomparison=true)
+    return (total=total, regressions=regressions, improvements=improvements, errors=nerrors, iscomparison=true)
 end
 
 function printsummary(io::IO, s::NamedTuple)
     if s.iscomparison
         println(io, "## Summary\n")
-        println(io, "**$(s.total)** benchmarks were executed, **$(s.regressions)** showed regressions, and **$(s.improvements)** showed improvements.")
+        msg = "**$(s.total)** benchmarks were executed, **$(s.regressions)** showed regressions, and **$(s.improvements)** showed improvements."
+        s.errors > 0 && (msg *= " **$(s.errors)** benchmarks failed.")
+        println(io, msg)
         println(io)
     else
         println(io, "## Summary\n")
-        println(io, "**$(s.total)** benchmarks were executed.")
+        msg = "**$(s.total)** benchmarks were executed."
+        s.errors > 0 && (msg *= " **$(s.errors)** benchmarks failed.")
+        println(io, msg)
         println(io)
     end
 end
@@ -764,6 +790,42 @@ function printreport(io::IO, job::BenchmarkJob, results)
     end
 
     println(io)
+
+    # print benchmark errors (if any) #
+    #----------------------------------#
+    primary_errors = get(results, "primary.errors", [])
+    against_errors = get(results, "against.errors", [])
+    if !isempty(primary_errors) || !isempty(against_errors)
+        println(io, "## Errors")
+        println(io)
+        println(io, "The following benchmarks failed during execution (check the build log for full stack traces):")
+        println(io)
+        if !isempty(primary_errors)
+            if iscomparisonjob
+                println(io, "#### Primary Build\n")
+            end
+            for entry in primary_errors
+                ids = entry["id"]
+                msg = entry["error"]
+                println(io, "- ", idrepr_md(ids), ": `", msg, "`")
+            end
+            println(io)
+        end
+        if !isempty(against_errors)
+            println(io, "#### Comparison Build\n")
+            for entry in against_errors
+                ids = entry["id"]
+                msg = entry["error"]
+                println(io, "- ", idrepr_md(ids), ": `", msg, "`")
+            end
+            println(io)
+        end
+        if length(primary_errors) >= MAX_BENCHMARK_ERRORS || length(against_errors) >= MAX_BENCHMARK_ERRORS
+            println(io, "**Note:** The maximum number of benchmark errors ($MAX_BENCHMARK_ERRORS) was reached; remaining benchmarks were skipped.")
+            println(io)
+        end
+        println(io)
+    end
 
     # print build version info #
     #--------------------------#


### PR DESCRIPTION
Run each benchmark leaf separately instead of the entire suite at once. Only the minimum TrialEstimate is kept per benchmark, allowing the full Trial sample data to be GC'd between runs.