### PR TITLE
update-testenvs: disable precompilation, use +nightly for latest version

### DIFF
--- a/.github/workflows/update-testenvs.yml
+++ b/.github/workflows/update-testenvs.yml
@@ -20,25 +20,34 @@ jobs:
       - name: Update manifests
         env:
           JULIA_PKG_USE_CLI_GIT: true
+          JULIA_PKG_PRECOMPILE_AUTO: '0'
         run: |
           export PATH="$HOME/.juliaup/bin:$PATH"
+
+          # Determine the highest versioned manifest — that version uses +nightly
+          # because it isn't available as a juliaup release channel yet.
+          highest_ver=$(ls testenvs/Manifest-v*.toml | sed 's|.*/Manifest-v||;s|\.toml||' \
+            | sort -t. -k1,1n -k2,2n | tail -1)
+          juliaup add nightly
 
           # Update each existing versioned manifest with its corresponding Julia version.
           # Julia X.Y writes back to Manifest-vX.Y.toml in-place when it finds one.
           for manifest in testenvs/Manifest-v*.toml; do
             ver=$(basename "$manifest" | sed 's/Manifest-v\(.*\)\.toml/\1/')
-            echo "--- Updating $manifest (Julia $ver) ---"
-            juliaup add "$ver"
-            julia "+$ver" --project=testenvs -e 'using Pkg; Pkg.update(); Pkg.status()'
+            if [ "$ver" = "$highest_ver" ]; then
+              channel=nightly
+            else
+              channel="$ver"
+              juliaup add "$channel"
+            fi
+            echo "--- Updating $manifest (Julia $ver via +$channel) ---"
+            julia "+$channel" --project=testenvs -e 'using Pkg; Pkg.update(); Pkg.status()'
           done
 
-          # Run nightly separately. If it has bumped to a new minor version there will
-          # be no matching Manifest-vX.Y.toml, so Pkg will fall back to creating
-          # Manifest.toml — rename it to the versioned name.
-          juliaup add nightly
+          # If nightly has bumped to a new minor version there will be no matching
+          # Manifest-vX.Y.toml, so Pkg will fall back to creating Manifest.toml —
+          # rename it to the versioned name.
           nightly_ver=$(julia +nightly -e 'print(VERSION.major, ".", VERSION.minor)')
-          echo "--- Nightly is Julia $nightly_ver ---"
-          julia +nightly --project=testenvs -e 'using Pkg; Pkg.update(); Pkg.status()'
           if [ -f testenvs/Manifest.toml ]; then
             echo "New nightly version ($nightly_ver) — creating Manifest-v${nightly_ver}.toml"
             mv testenvs/Manifest.toml "testenvs/Manifest-v${nightly_ver}.toml"


### PR DESCRIPTION
- Set JULIA_PKG_PRECOMPILE_AUTO=0 to skip unnecessary precompilation
- Route the highest manifest version through +nightly since it isn't available as a juliaup release channel yet