### PR TITLE
Add summary image to completion comment; center plot x-axis

### DIFF
--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -659,6 +659,11 @@ function report(job::BenchmarkJob, results)
             The benchmark job [you requested]($(submission(job).url)) has completed - $status. $(summary_line)
             *Commit$(job.against !== nothing ? "s" : ""):* $(commit_line)
             The [**full report**]($(target_url)) is available."""
+        if s.iscomparison
+            cfg = submission(job).config
+            summary_img_url = "https://github.com/$(reportrepo(cfg))/raw/master/benchmark/$(jobdirname(job))/summary.png"
+            comment *= "\n<img src=$(summary_img_url)>"
+        end
         reply_comment(submission(job), comment)
     end
 end

--- a/src/jobs/summary_plot.jl
+++ b/src/jobs/summary_plot.jl
@@ -69,7 +69,8 @@ function write_summary_plot(dest_path::AbstractString,
     y_gap_center = nr + 0.5 + GAP / 2
 
     xpad = 0.45
-    xlims_top = (minimum(xvals) - xpad, maximum(xvals) + xpad)
+    half_range = maximum(abs.(xvals)) + xpad
+    xlims_top = (-half_range, half_range)
     xticks_pos = [-1, -0.5, 0, 0.5, 1, 1.5, 2, 2.5, 3]
     xticks_lab = [@sprintf("%.2g×", 2.0^t) for t in xticks_pos]
 


### PR DESCRIPTION
- Include the summary.png image as an <img> tag in the GitHub comment posted when a comparison benchmark job completes
- Make the summary plot x-axis symmetric around 0 so the 1× center line is always at the midpoint of the x-axis