### PR TITLE
Open tracking issue for severe daily benchmark regressions

### DIFF
--- a/bin/run_base_ci.jl
+++ b/bin/run_base_ci.jl
@@ -10,6 +10,7 @@ port = Int(0xffff)
 
 config = Nanosoldier.Config("nanosoldier-worker", nodes, auth, secret;
                             reportrepo = "JuliaCI/NanosoldierReports",
+                            issuerepo = "JuliaLang/julia",
                             testmode = false)
 
 server = Nanosoldier.Server(config)

--- a/src/config.jl
+++ b/src/config.jl
@@ -9,6 +9,7 @@ struct Config
     admin::String                   # GitHub handle of the server administrator
     bucket::Union{Nothing,String}   # AWS bucket to upload large files too
     testmode::Bool                  # if true, jobs will run as test jobs
+    issuerepo::Union{Nothing,String} # the repo where daily regression issues are opened (nothing disables)
 
     function Config(user, nodes, auth, secret;
                     cpus = Dict{Int,Vector{Int}}(),
@@ -16,10 +17,11 @@ struct Config
                     trigger =  r"\@nanosoldier\s*`runbenchmarks\(.*?\)`",
                     admin = "",
                     bucket = nothing,
-                    testmode = false)
+                    testmode = false,
+                    issuerepo = nothing)
         isempty(nodes) && throw(ArgumentError("need at least one node to work on"))
         return new(user, nodes, cpus, auth, secret,
-                   reportrepo, trigger, admin, bucket, testmode)
+                   reportrepo, trigger, admin, bucket, testmode, issuerepo)
     end
 end
 

--- a/src/jobs/BenchmarkJob.jl
+++ b/src/jobs/BenchmarkJob.jl
@@ -665,7 +665,108 @@ function report(job::BenchmarkJob, results)
             comment *= "\n<img src=$(summary_img_url)>"
         end
         reply_comment(submission(job), comment)
+
+        # for daily jobs, open a tracking issue if any benchmarks regressed severely
+        if job.isdaily
+            try
+                open_regression_issue(job, results, target_url)
+            catch err
+                nodelog(cfg, node, "failed to open regression issue", error=err)
+            end
+        end
     end
+end
+
+# Regression Issue Reporting #
+#----------------------------#
+
+# A daily benchmark time regression is severe enough to open a tracking issue
+# once its time ratio (primary / previous) reaches this threshold (i.e. +50%).
+const DAILY_ISSUE_REGRESSION_RATIO = 1.5
+
+# Traverse a BenchmarkGroup along `ids` and return the recorded time (ns), or
+# `nothing` if the path is missing or doesn't terminate in an estimate.
+function lookup_estimate_time(group, ids)
+    node = group
+    for id in ids
+        node isa BenchmarkTools.BenchmarkGroup && haskey(node, id) || return nothing
+        node = node[id]
+    end
+    return node isa BenchmarkTools.TrialEstimate ? BenchmarkTools.time(node) : nothing
+end
+
+# Collect benchmarks whose time regressed by at least `ratio_threshold` between
+# the previous (`against`) and current (`primary`) builds, sorted worst-first.
+function severe_time_regressions(results; ratio_threshold=DAILY_ISSUE_REGRESSION_RATIO)
+    haskey(results, "judged") || return NamedTuple[]
+    primary = get(results, "primary", nothing)
+    against = get(results, "against", nothing)
+    regressions = NamedTuple[]
+    for (ids, t) in BenchmarkTools.leaves(results["judged"])
+        BenchmarkTools.time(t) === :regression || continue
+        ratio = BenchmarkTools.time(BenchmarkTools.ratio(t))
+        ratio >= ratio_threshold || continue
+        push!(regressions, (ids = ids, ratio = ratio,
+                            primarytime = primary === nothing ? nothing : lookup_estimate_time(primary, ids),
+                            againsttime = against === nothing ? nothing : lookup_estimate_time(against, ids)))
+    end
+    sort!(regressions; by = r -> r.ratio, rev = true)
+    return regressions
+end
+
+# Build the (title, body) for a daily regression tracking issue.
+function regression_issue_content(job::BenchmarkJob, results, regressions, target_url)
+    build = submission(job).build
+    previous_sha = get(results, "previous_sha", "")
+    n = length(regressions)
+    plural = n == 1 ? "" : "s"
+
+    io = IOBuffer()
+    println(io, "The [daily benchmark build]($(target_url)) for $(job.date) detected ",
+                "**$(n)** benchmark$(plural) that regressed by 50% or more relative to the previous daily build.")
+    println(io)
+    println(io, "| Benchmark | time ratio | before → after |")
+    println(io, "|-----------|-----------:|----------------|")
+    for r in regressions
+        before = r.againsttime === nothing ? "?" : BenchmarkTools.prettytime(r.againsttime)
+        after = r.primarytime === nothing ? "?" : BenchmarkTools.prettytime(r.primarytime)
+        println(io, "| ", idrepr_md(r.ids), " | ", @sprintf("%.2fx", r.ratio), " | ", before, " → ", after, " |")
+    end
+    println(io)
+
+    if !isempty(previous_sha)
+        comparelink = "https://github.com/$(build.repo)/compare/$(previous_sha)...$(build.sha)"
+        perflink = "https://perf.julialang.org/?tab=perf&start=$(previous_sha)&end=$(build.sha)&stat=min-wall-time"
+        println(io, "*Commit range:* [`$(snipsha(previous_sha))`...`$(snipsha(build.sha))`]($(comparelink))")
+        println(io)
+        println(io, "*Comparison on perf.julialang.org:* [link]($(perflink))")
+        println(io)
+    end
+    println(io, "*Full report:* [link]($(target_url))")
+
+    title = "Daily benchmark regressions for $(job.date): $(n) benchmark$(plural) ≥50% slower"
+    return title, String(take!(io))
+end
+
+# Open a GitHub issue summarizing severe daily regressions, if any. Does nothing
+# unless the job is daily, the config opts in via `issuerepo`, and at least one
+# benchmark crossed the regression threshold.
+function open_regression_issue(job::BenchmarkJob, results, target_url)
+    cfg = submission(job).config
+    issuerepo = cfg.issuerepo
+    issuerepo === nothing && return nothing
+    haskey(results, "previous_date") || return nothing
+
+    regressions = severe_time_regressions(results)
+    isempty(regressions) && return nothing
+
+    title, body = regression_issue_content(job, results, regressions, target_url)
+    if haskey(ENV, "NANOSOLDIER_DRYRUN")
+        @info "Running as part of test suite, not opening regression issue" title
+        return nothing
+    end
+    return GitHub.create_issue(issuerepo; auth = cfg.auth,
+                               params = Dict("title" => title, "body" => body))
 end
 
 # Markdown Report Generation #

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -280,6 +280,33 @@ mkpath(reportoutdir)
     end
 end
 
+@testset "Daily regression issue" begin
+    regressions = Nanosoldier.severe_time_regressions(results)
+    # only ("y", 1) regressed in time (2.0x); "z" only regressed in memory
+    @test length(regressions) == 1
+    r = regressions[1]
+    @test r.ids == ["g", "h", ("y", 1)]
+    @test r.ratio == 2.0
+    @test r.primarytime == 2.0
+    @test r.againsttime == 1.0
+
+    @test isempty(Nanosoldier.severe_time_regressions(results; ratio_threshold=3.0))
+
+    daily_results = copy(results)
+    daily_results["previous_sha"] = against_commit.sha
+    daily_results["previous_date"] = job.date
+    title, body = Nanosoldier.regression_issue_content(job, daily_results, regressions, "https://example.com/report.md")
+    @test occursin("≥50% slower", title)
+    @test occursin("1 benchmark", title)
+    @test occursin("2.00x", body)
+    @test occursin("perf.julialang.org/?tab=perf&start=$(against_commit.sha)&end=$(primary_commit.sha)", body)
+    @test occursin("compare/$(against_commit.sha)...$(primary_commit.sha)", body)
+    @test occursin("https://example.com/report.md", body)
+
+    # opt-out (issuerepo === nothing) must not attempt to open an issue
+    @test Nanosoldier.open_regression_issue(job, daily_results, "https://example.com/report.md") === nothing
+end
+
 @testset "Markdown" begin
     @test Nanosoldier.markdown_escaped("abc") == "abc"
     @test Nanosoldier.markdown_escaped(raw"a\`*_#+-.!{}[]()<>|b") == raw"a\\\`\*\_\#\+\-\.\!\{\}\[\]\(\)\<\>\|b"


### PR DESCRIPTION
@vtjnash worth trying out?


Claude:

----

On `isdaily` benchmark runs, file a concise GitHub issue when any benchmark regresses in time by 50% or more relative to the previous daily build. The issue lists the affected benchmarks with before/after timings and ratios, the commit comparison range, a link back to the full report, and a perf.julialang.org comparison link.

Issue filing is gated behind a new opt-in `issuerepo` Config field (default `nothing` = disabled); enabled for `JuliaLang/julia` in run_base_ci.jl.